### PR TITLE
Fix bottom of popup HTML

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -606,10 +606,8 @@
         </div>
     </div>
     <!-- Move external JS to the bottom -->
-    <script src="settings.js"></script>
     <script src="popup.js" defer></script>
 
-    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- remove unused script tag from `popup.html`
- drop stray `</script>` line

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f45598cf88330b0b6851c5809ca21