### PR TITLE
Remove hidden copy buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ The full changelog and feature history is maintained here.
 
 Current Known Bugs:
 - Collapse sidebar GPT's and Folders is down for repairs
-- Copy and join all code boxes is including text outside of code boxes. This feature may be retired soon. 
+- Copy and join all code boxes is including text outside of code boxes. This feature may be retired soon.
+
+#### [6.3.2025]
+##### Removed
+- Legacy code for hidden "Copy All" buttons
 
 #### [5.29.2025]
 - Disabled collapse sidebar for time being.

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -98,9 +98,6 @@
     "label_hide_arrows": {
         "message": "Hide Arrow Buttons"
     },
-    "label_hide_corners": {
-        "message": "Hide Copy All Buttons"
-    },
     "tt_scroll_up_one": {
         "message": "Scroll up one message at a time. To disable any shortcut, delete the assigned letter."
     },
@@ -196,9 +193,6 @@
     },
     "tt_hide_arrows": {
         "message": "Hide the up and down arrow buttons."
-    },
-    "tt_hide_corners": {
-        "message": "Hide the 'Copy All' buttons in the bottom right."
     },
     "label_showModelPicker": {
         "message": "Show Model Picker"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -98,9 +98,6 @@
     "label_hide_arrows": {
         "message": "Ocultar botones de flecha"
     },
-    "label_hide_corners": {
-        "message": "Ocultar botones 'Copiar todo'"
-    },
     "tt_scroll_up_one": {
         "message": "Sube un mensaje cada vez. Borra el atajo para desactivar."
     },
@@ -196,9 +193,6 @@
     },
     "tt_hide_arrows": {
         "message": "Oculta los botones de flecha."
-    },
-    "tt_hide_corners": {
-        "message": "Oculta botones 'Copiar todo' en esquina inferior derecha."
     },
     "label_showModelPicker": {
         "message": "Mostrar selector de modelo"

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -98,9 +98,6 @@
     "label_hide_arrows": {
         "message": "ऊपर/नीचे बटन छुपाएँ"
     },
-    "label_hide_corners": {
-        "message": "कॉपी ऑल बटन छुपाएँ"
-    },
     "tt_scroll_up_one": {
         "message": "एक-एक संदेश ऊपर स्क्रॉल करें। बंद करने के लिए शॉर्टकट हटाएँ।"
     },
@@ -196,9 +193,6 @@
     },
     "tt_hide_arrows": {
         "message": "ऊपर-नीचे वाले एरो बटन छुपाएँ।"
-    },
-    "tt_hide_corners": {
-        "message": "'कॉपी ऑल' बटन छुपाएँ।"
     },
     "label_showModelPicker": {
         "message": "मॉडल पिकर दिखाएं"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -98,9 +98,6 @@
     "label_hide_arrows": {
         "message": "矢印ボタン非表示"
     },
-    "label_hide_corners": {
-        "message": "'全てコピー'非表示"
-    },
     "tt_scroll_up_one": {
         "message": "1つずつ上にスクロール（削除で無効化）。"
     },
@@ -196,9 +193,6 @@
     },
     "tt_hide_arrows": {
         "message": "上下矢印ボタンを非表示。"
-    },
-    "tt_hide_corners": {
-        "message": "右下の'全てコピー'ボタン非表示。"
     },
     "label_showModelPicker": {
         "message": "モデル選択を表示"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -98,9 +98,6 @@
     "label_hide_arrows": {
         "message": "Скрыть стрелки"
     },
-    "label_hide_corners": {
-        "message": "Скрыть кнопки 'Копировать всё'"
-    },
     "tt_scroll_up_one": {
         "message": "Прокрутка вверх по одному сообщению. Удалите клавишу для отключения."
     },
@@ -196,9 +193,6 @@
     },
     "tt_hide_arrows": {
         "message": "Скрывает кнопки-стрелки."
-    },
-    "tt_hide_corners": {
-        "message": "Скрывает кнопки 'Копировать всё' справа внизу."
     },
     "label_showModelPicker": {
         "message": "Показать выбор модели"

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -98,9 +98,6 @@
     "label_hide_arrows": {
         "message": "Сховати кнопки зі стрілками"
     },
-    "label_hide_corners": {
-        "message": "Сховати кнопки копіювання"
-    },
     "tt_scroll_up_one": {
         "message": "Прокрутити вверх на одне повідомлення (очистіть для вимкнення)."
     },
@@ -196,9 +193,6 @@
     },
     "tt_hide_arrows": {
         "message": "Сховати кнопки зі стрілками."
-    },
-    "tt_hide_corners": {
-        "message": "Сховати кнопки копіювання всього внизу справа."
     },
     "label_showModelPicker": {
         "message": "Показати вибір моделі"

--- a/content.js
+++ b/content.js
@@ -125,13 +125,6 @@ function findButton(args) {
             });
         }
 
-        // Check and hide the menu buttons if necessary
-        if (data.hideCornerButtonsCheckbox) {
-            ['copyAllButton', 'copyCodeButton'].forEach(id => {
-                const button = document.getElementById(id);
-                if (button) button.style.display = 'none';
-            });
-        }
 
         // Define default values globally
 
@@ -185,7 +178,6 @@ function findButton(args) {
     // Fetch initial values from Chrome storage
     chrome.storage.sync.get([
         'hideArrowButtonsCheckbox',
-        'hideCornerButtonsCheckbox',
         'moveTopBarToBottomCheckbox',
         'removeMarkdownOnCopyCheckbox',
         'selectMessagesSentByUserOrChatGptCheckbox',
@@ -208,9 +200,6 @@ function findButton(args) {
             const updatedData = {};
             if (changes.hideArrowButtonsCheckbox) {
                 updatedData.hideArrowButtonsCheckbox = changes.hideArrowButtonsCheckbox.newValue;
-            }
-            if (changes.hideCornerButtonsCheckbox) {
-                updatedData.hideCornerButtonsCheckbox = changes.hideCornerButtonsCheckbox.newValue;
             }
             if (changes.moveTopBarToBottomCheckbox) {
                 updatedData.moveTopBarToBottomCheckbox = changes.moveTopBarToBottomCheckbox.newValue;
@@ -322,110 +311,8 @@ function findButton(args) {
 
 
 
-    function createButton(icon, onClick, tooltipText, id) {
-        const button = document.createElement('button');
-        button.style.cssText = "width: 20px; height: 20px; border: none; background: none; margin-right: 16px; cursor: pointer;";
-
-        // Parse the SVG string into a DOM Node
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(icon, 'image/svg+xml');
-        const svgNode = doc.firstChild;
-
-        // Apply initial color
-        svgNode.setAttribute('fill', 'var(--text-secondary)');
-        button.appendChild(svgNode);
-
-        button.addEventListener('click', onClick);
-        button.id = id;
-
-        button.addEventListener('mouseenter', () => {
-            svgNode.setAttribute('fill', '#AB68FD'); // Change the fill color of the SVG
-        });
-
-        button.addEventListener('mouseleave', () => {
-            svgNode.setAttribute('fill', 'var(--text-secondary)'); // Change it back
-        });
-
-        if (tooltipText) {
-            addTooltip(button, tooltipText);
-        }
-
-        return button;
-    }
-
-    async function loadSVG(iconPath) {
-        const response = await fetch(chrome.runtime.getURL(iconPath));
-        const text = await response.text();
-        return text;
-    }
 
 
-    async function createMenu() {
-        // Load SVGs
-        const copyAllIconSVG = await loadSVG('icons/copy-all-text-icon.svg');
-        const copyCodeIconSVG = await loadSVG('icons/copy-all-code-icon.svg');
-
-        // Create buttons
-        const copyAllButton = createButton(copyAllIconSVG, copyAll, "Copy and Join All Responses", 'copyAllButton');
-        const copyCodeButton = createButton(copyCodeIconSVG, copyCode, "Copy and Join All Code Boxes", 'copyCodeButton');
-
-        // Position the buttons
-        copyAllButton.style.cssText = "display:none; position: fixed; zoom: .65; bottom: 6px; right: 100px; width: 32px; height: 32px; border: none; background: none; cursor: pointer; transition: opacity 1s;";
-        copyCodeButton.style.cssText = "display:none; position: fixed; zoom: .65; bottom: 6px; right: 60px; width: 32px; height: 32px; border: none; background: none; cursor: pointer; transition: opacity 1s;";
-
-        // Append buttons to the body
-        appendWithFragment(document.body, copyAllButton, copyCodeButton);
-
-        // Add opacity logic to the buttons
-        const copyButtons = [copyAllButton, copyCodeButton];
-
-        copyButtons.forEach(button => {
-            // Mouseover: make button fully visible
-            button.addEventListener('mouseover', () => {
-                button.style.opacity = "1";
-            });
-
-            // Mouseleave: fade the button
-            button.addEventListener('mouseleave', () => {
-                button.style.transition = "opacity 1s";
-                button.style.opacity = "0.2";
-            });
-
-            // Initial fade after a delay (3500ms)
-            setTimeout(() => {
-                button.style.transition = "opacity 1s";
-                button.style.opacity = "0.2";
-            }, 3500);
-        });
-
-        function applyVisibilitySettings(data) {
-            // Check and hide the up button if necessary
-            if (data.hideArrowButtonsCheckbox) {
-                const upButton = document.getElementById('upButton');
-                if (upButton) {
-                    upButton.style.display = 'none';
-                }
-            }
-
-            // Check and hide the menu buttons if necessary
-            if (data.hideCornerButtonsCheckbox) {
-                const copyAllButton = document.getElementById('copyAllButton');
-                const copyCodeButton = document.getElementById('copyCodeButton');
-
-                if (copyAllButton) copyAllButton.style.display = 'none';
-                if (copyCodeButton) copyCodeButton.style.display = 'none';
-            }
-
-        }
-
-        // Get the values from Chrome storage
-        chrome.storage.sync.get(['hideArrowButtonsCheckbox', 'hideCornerButtonsCheckbox'], function (data) {
-            applyVisibilitySettings(data);
-        });
-    }
-
-    // Call createMenu without awaiting it
-    createMenu();
 
     function showToast(message) {
         const toast = document.createElement('div');
@@ -768,6 +655,9 @@ function findButton(args) {
     const upButton = createScrollUpButton();
     const downButton = createScrollDownButton();
     appendWithFragment(document.body, upButton, downButton);
+
+    // Apply visibility settings now that buttons exist
+    chrome.storage.sync.get('hideArrowButtonsCheckbox', applyVisibilitySettings);
 
 
     // @note Keyboard shortcut defaults 

--- a/popup.html
+++ b/popup.html
@@ -581,21 +581,6 @@
                     </label>
                 </div>
             </div>
-            <div class="shortcut-item" style="display:none!important">
-                <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_hide_corners__">
-                    <span class="i18n" data-i18n="label_hide_corners">
-                        Hide Copy All Buttons
-                    </span>
-                </div>
-                <div class="icon-input-container">
-                    <span class="tooltip" data-tooltip="__MSG_tt_hide_corners__">
-                        <span class="material-symbols-outlined">
-                            file_copy_off
-                        </span>
-                    </span>
-                    <input checked="" id="hideCornerButtonsCheckbox" name="hideCornerButtonsCheckbox" type="checkbox" />
-                </div>
-            </div>
             <!-- Blank Rows -->
             <div class="blank-row">
             </div>

--- a/popup.js
+++ b/popup.js
@@ -251,7 +251,6 @@ document.addEventListener('DOMContentLoaded', function () {
     chrome.storage.sync.get(
         [
             'hideArrowButtonsCheckbox',
-            'hideCornerButtonsCheckbox',
             'removeMarkdownOnCopyCheckbox',
             'moveTopBarToBottomCheckbox',
             'pageUpDownTakeover',
@@ -268,7 +267,6 @@ document.addEventListener('DOMContentLoaded', function () {
         function (data) {
             const defaults = {
                 hideArrowButtonsCheckbox: data.hideArrowButtonsCheckbox !== undefined ? data.hideArrowButtonsCheckbox : false,
-                hideCornerButtonsCheckbox: data.hideCornerButtonsCheckbox === undefined ? true : data.hideCornerButtonsCheckbox,
                 removeMarkdownOnCopyCheckbox: data.removeMarkdownOnCopyCheckbox !== undefined ? data.removeMarkdownOnCopyCheckbox : true,
                 moveTopBarToBottomCheckbox: data.moveTopBarToBottomCheckbox !== undefined ? data.moveTopBarToBottomCheckbox : false,
                 pageUpDownTakeover: data.pageUpDownTakeover !== undefined ? data.pageUpDownTakeover : true,
@@ -285,7 +283,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
             // Update the popup's checkboxes and radio buttons based on stored or default values
             document.getElementById('hideArrowButtonsCheckbox').checked = defaults.hideArrowButtonsCheckbox;
-            document.getElementById('hideCornerButtonsCheckbox').checked = defaults.hideCornerButtonsCheckbox;
             document.getElementById('removeMarkdownOnCopyCheckbox').checked = defaults.removeMarkdownOnCopyCheckbox;
             document.getElementById('moveTopBarToBottomCheckbox').checked = defaults.moveTopBarToBottomCheckbox;
             document.getElementById('pageUpDownTakeover').checked = defaults.pageUpDownTakeover;
@@ -302,7 +299,6 @@ document.addEventListener('DOMContentLoaded', function () {
             // Only sync default values for keys that were not yet set in storage
             const toSync = {};
             if (data.hideArrowButtonsCheckbox === undefined) toSync.hideArrowButtonsCheckbox = defaults.hideArrowButtonsCheckbox;
-            if (data.hideCornerButtonsCheckbox === undefined) toSync.hideCornerButtonsCheckbox = defaults.hideCornerButtonsCheckbox;
             if (data.removeMarkdownOnCopyCheckbox === undefined) toSync.removeMarkdownOnCopyCheckbox = defaults.removeMarkdownOnCopyCheckbox;
             if (data.moveTopBarToBottomCheckbox === undefined) toSync.moveTopBarToBottomCheckbox = defaults.moveTopBarToBottomCheckbox;
             if (data.pageUpDownTakeover === undefined) toSync.pageUpDownTakeover = defaults.pageUpDownTakeover;
@@ -375,7 +371,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Apply the handler to each checkbox and radio button
     handleStateChange('hideArrowButtonsCheckbox', 'hideArrowButtonsCheckbox');
-    handleStateChange('hideCornerButtonsCheckbox', 'hideCornerButtonsCheckbox');
     handleStateChange('removeMarkdownOnCopyCheckbox', 'removeMarkdownOnCopyCheckbox');
     handleStateChange('moveTopBarToBottomCheckbox', 'moveTopBarToBottomCheckbox');
     handleStateChange('pageUpDownTakeover', 'pageUpDownTakeover');


### PR DESCRIPTION
## Summary
- drop creation of unused copy buttons
- clean up popup code and locales
- document removal in changelog

## Testing
- `npm ci` *(fails: lockfile missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f7a0530308330b7f969dc056a3513