### PR TITLE
Fix TopBarToBottom boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Current Known Bugs:
 - Collapse sidebar GPT's and Folders is down for repairs
 - Copy and join all code boxes is including text outside of code boxes. This feature may be retired soon.
 
+#### [6.4.2025]
+##### Fixed
+- Normalized TopBarToBottom flag as a boolean and updated scroll logic.
+
 #### [6.3.2025]
 ##### Changed
 - Refactored visibility settings logic for content script.

--- a/content.js
+++ b/content.js
@@ -122,9 +122,8 @@ function applyVisibilitySettings(data) {
         });
     }
 
-    window.moveTopBarToBottomCheckbox = data.hasOwnProperty('moveTopBarToBottomCheckbox')
-        ? data.moveTopBarToBottomCheckbox === true
-        : false;
+    // Normalize to boolean for easier checks throughout the script
+    window.moveTopBarToBottomCheckbox = Boolean(data.moveTopBarToBottomCheckbox);
 
     window.removeMarkdownOnCopyCheckbox = data.hasOwnProperty('removeMarkdownOnCopyCheckbox')
         ? data.removeMarkdownOnCopyCheckbox === true
@@ -555,7 +554,7 @@ window.applyVisibilitySettings = applyVisibilitySettings;
             let targetMessage = null;
 
             // Determine offset values based on checkbox state
-            const isBottom = window.moveTopBarToBottomCheckbox?.checked;
+            const isBottom = window.moveTopBarToBottomCheckbox;
             const messageThreshold = isBottom ? -48 : -30;      // 2nd # is if TopBarToBottom is checked, 1st  # when topbar in default position
             const scrollOffset = isBottom ? 43 : 25;            // 2nd # is if TopBarToBottom is checked, 1st  # when topbar in default position
 
@@ -646,7 +645,7 @@ window.applyVisibilitySettings = applyVisibilitySettings;
             const currentScrollTop = scrollContainer.scrollTop;
 
             // Determine offset values based on checkbox state
-            const isBottom = window.moveTopBarToBottomCheckbox?.checked;
+            const isBottom = window.moveTopBarToBottomCheckbox;
             const messageThreshold = isBottom ? 48 : 30;         // Mirror logic from upButton, reversed for downward scroll
             const scrollOffset = isBottom ? 43 : 25;             // Matching offset values
 


### PR DESCRIPTION
## Summary
- handle `moveTopBarToBottomCheckbox` as a boolean
- remove `.checked` reads when determining bar position
- document fix in changelog

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f8a3e235c83308fd2c1685f48583c