### PR TITLE
Remove copy all buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The full changelog and feature history is maintained here.
 
 Current Known Bugs:
 
+#### [6.5.2025]
+##### Removed
+- Permanently removed "Copy All" buttons; features remain accessible via keyboard shortcuts.
+
 #### [6.4.2025]
 ##### Fixed
 - Ensure GSAP plugins register only after libraries load.

--- a/content.js
+++ b/content.js
@@ -109,13 +109,6 @@ function applyVisibilitySettings(data) {
         });
     }
 
-    if (data.hideCornerButtonsCheckbox) {
-        ['copyAllButton', 'copyCodeButton'].forEach(id => {
-            const button = document.getElementById(id);
-            if (button) button.style.display = 'none';
-        });
-    }
-
     // Normalize to boolean for easier checks throughout the script
     window.moveTopBarToBottomCheckbox = Boolean(data.moveTopBarToBottomCheckbox);
 
@@ -299,87 +292,6 @@ window.applyVisibilitySettings = applyVisibilitySettings;
 
 
 
-    function createButton(icon, onClick, tooltipText, id) {
-        const button = document.createElement('button');
-        button.style.cssText = "width: 20px; height: 20px; border: none; background: none; margin-right: 16px; cursor: pointer;";
-
-        // Parse the SVG string into a DOM Node
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(icon, 'image/svg+xml');
-        const svgNode = doc.firstChild;
-
-        // Apply initial color
-        svgNode.setAttribute('fill', 'var(--text-secondary)');
-        button.appendChild(svgNode);
-
-        button.addEventListener('click', onClick);
-        button.id = id;
-
-        button.addEventListener('mouseenter', () => {
-            svgNode.setAttribute('fill', '#AB68FD'); // Change the fill color of the SVG
-        });
-
-        button.addEventListener('mouseleave', () => {
-            svgNode.setAttribute('fill', 'var(--text-secondary)'); // Change it back
-        });
-
-
-        return button;
-    }
-
-    async function loadSVG(iconPath) {
-        const response = await fetch(chrome.runtime.getURL(iconPath));
-        const text = await response.text();
-        return text;
-    }
-
-
-    async function createMenu() {
-        // Load SVGs
-        const copyAllIconSVG = await loadSVG('icons/copy-all-text-icon.svg');
-        const copyCodeIconSVG = await loadSVG('icons/copy-all-code-icon.svg');
-
-        // Create buttons
-        const copyAllButton = createButton(copyAllIconSVG, copyAll, "Copy and Join All Responses", 'copyAllButton');
-        const copyCodeButton = createButton(copyCodeIconSVG, copyCode, "Copy and Join All Code Boxes", 'copyCodeButton');
-
-        // Position the buttons
-        copyAllButton.style.cssText = "display:none; position: fixed; zoom: .65; bottom: 6px; right: 100px; width: 32px; height: 32px; border: none; background: none; cursor: pointer; transition: opacity 1s;";
-        copyCodeButton.style.cssText = "display:none; position: fixed; zoom: .65; bottom: 6px; right: 60px; width: 32px; height: 32px; border: none; background: none; cursor: pointer; transition: opacity 1s;";
-
-        // Append buttons to the body
-        appendWithFragment(document.body, copyAllButton, copyCodeButton);
-
-        // Add opacity logic to the buttons
-        const copyButtons = [copyAllButton, copyCodeButton];
-
-        copyButtons.forEach(button => {
-            // Mouseover: make button fully visible
-            button.addEventListener('mouseover', () => {
-                button.style.opacity = "1";
-            });
-
-            // Mouseleave: fade the button
-            button.addEventListener('mouseleave', () => {
-                button.style.transition = "opacity 1s";
-                button.style.opacity = "0.2";
-            });
-
-            // Initial fade after a delay (3500ms)
-            setTimeout(() => {
-                button.style.transition = "opacity 1s";
-                button.style.opacity = "0.2";
-            }, 3500);
-        });
-
-        // Get the values from Chrome storage
-        chrome.storage.sync.get(['hideArrowButtonsCheckbox', 'hideCornerButtonsCheckbox'], function (data) {
-            applyVisibilitySettings(data);
-        });
-    }
-
-    // Call createMenu without awaiting it
-    createMenu();
 
     function showToast(message) {
         const toast = document.createElement('div');


### PR DESCRIPTION
## Summary
- delete deprecated copy buttons logic
- clean up `applyVisibilitySettings`
- document permanent removal of copy buttons in changelog

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f919e75148330984ec5635676b9bc