### PR TITLE
Fix top bar swap for Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The full changelog and feature history is maintained here.
 
 Current Known Bugs:
 
+#### [6.8.2025]
+##### Fixed
+- Automatically disable TopBarToBottom on Codex pages.
+
 #### [6.5.2025]
 ##### Removed
 - Permanently removed "Copy All" buttons; features remain accessible via keyboard shortcuts.

--- a/content.js
+++ b/content.js
@@ -1868,6 +1868,10 @@ div[data-testid="accounts-profile-button"] div.truncate {
         ({ moveTopBarToBottomCheckbox: enabled }) => {
             if (!enabled) return;
 
+            const isCodex = location.hostname.endsWith('chatgpt.com') &&
+                location.pathname.startsWith('/codex');
+            if (isCodex) return;
+
             setTimeout(function injectBottomBarStyles() {
 
                 // -------------------- Section 1. Utilities --------------------


### PR DESCRIPTION
## Summary
- disable TopBarToBottom on Codex pages
- note the behavior in the changelog

## Testing
- `npm ci && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684123c1ef98833089420cfe95d2617e