### PR TITLE
Fix appendWithFragment handling of null elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The full changelog and feature history is maintained here.
 
 Current Known Bugs:
 
+#### [6.6.2025]
+##### Fixed
+- Handle missing arrow buttons when appending elements.
+
 #### [6.5.2025]
 ##### Removed
 - Permanently removed "Copy All" buttons; features remain accessible via keyboard shortcuts.

--- a/content.js
+++ b/content.js
@@ -178,7 +178,9 @@ window.applyVisibilitySettings = applyVisibilitySettings;
 
     function appendWithFragment(parent, ...elements) {
         const fragment = document.createDocumentFragment();
-        elements.forEach(element => fragment.appendChild(element));
+        elements
+            .filter(el => el !== null && el !== undefined)
+            .forEach(el => fragment.appendChild(el));
         parent.appendChild(fragment);
     }
 


### PR DESCRIPTION
## Summary
- skip undefined nodes in appendWithFragment
- log change in CHANGELOG

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841233003a08330ad4631a3a30adecf