### PR TITLE
Remove model picker NEW badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The full changelog and feature history is maintained here.
 - Permanently removed "Copy All" buttons; features remain accessible via keyboard shortcuts.
 - Automatically disable TopBarToBottom on Codex pages.
 - Handle missing arrow buttons when appending elements.
+- Removed NEW badges from Model Picker shortcuts.
 
 ##### Removed
 - Unused message caching logic.

--- a/popup.html
+++ b/popup.html
@@ -145,10 +145,6 @@
 
             <!-- Row 4.1 Model Picker Shortcuts-->
             <div class="shortcut-item" style="position: relative;">
-                <span class="new-feature-tag"
-                    style="position: absolute; top: -8px; left: -8px; transform: translate(-25%, -25%); z-index: 2;">
-                    <span class="i18n" data-i18n="tag_new">NEW</span>
-                </span>
                 <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_showModelPicker_plain__">
                     <span class="i18n" data-i18n="label_showModelPicker">Show Model Picker</span>
                 </div>
@@ -160,10 +156,6 @@
             </div>
 
             <div class="shortcut-item" style="position: relative;">
-                <span class="new-feature-tag"
-                    style="position: absolute; top: -8px; left: -8px; transform: translate(-25%, -25%); z-index: 2;">
-                    <span class="i18n" data-i18n="tag_new">NEW</span>
-                </span>
                 <div style="flex: 1;">
                     <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_pick_model_plain__"
                         style="margin-bottom: 4px;">


### PR DESCRIPTION
## Summary
- remove NEW badges from model picker shortcuts in popup
- keep Regenerate Response badge
- document badge removal

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68413026174483309e71505ccdfa6dba