### PR TITLE
Fix duplicate CSS links in popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1,9 +1,10 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <link rel="stylesheet" href="lib/puppertino/newfull.css" />
     <link href="popup.css" rel="stylesheet" />
     <title>
         ChatGPT Custom Shortcuts Pro
@@ -12,8 +13,6 @@
 
 <body>
     <!-- Puppertino and icons CSS -->
-    <link rel="stylesheet" href="lib/puppertino/newfull.css" />
-    <link rel="stylesheet" href="popup.css" />
 
     <div class="shortcut-container">
         <h1 class="i18n" data-i18n="popup_title">


### PR DESCRIPTION
## Summary
- remove duplicate popup.css link
- link Puppertino CSS in `<head>`
- drop UTF-8 BOM from popup.html

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849c24efd2c833094af5c050e3a67a2