### PR TITLE
Reduce custom styles to match Puppertino

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -5,19 +5,19 @@
 
 /* Define color tokens */
 :root {
-    --text-primary: #1e1e1e;
-    --text-secondary: #646464;
-    --border-light: #dfdfdc;
-    --bg-primary: #f4f3f1;
-    --bg-secondary: #f8f7f5;
-    --highlight-color: #3f51b5;
-    --segment-bg: #f8f7f5;
-    --segment-border: #e0e0e6;
-    --segment-active-bg: #fff;
-    --segment-active-border: #b8d4ff;
+    --text-primary: var(--p-dark-700);
+    --text-secondary: var(--p-silver-700);
+    --border-light: var(--p-silver-300);
+    --bg-primary: var(--p-silver-100);
+    --bg-secondary: var(--p-silver-100);
+    --highlight-color: var(--p-blueberry-500);
+    --segment-bg: var(--p-silver-100);
+    --segment-border: var(--p-silver-300);
+    --segment-active-bg: var(--p-silver-100);
+    --segment-active-border: var(--p-blueberry-300);
     --segment-active-shadow: 0 2.5px 10px 0 rgba(0, 122, 255, 0.06);
-    --segment-text: #333;
-    --segment-active-text: #007aff;
+    --segment-text: var(--p-dark-700);
+    --segment-active-text: var(--p-blueberry-500);
 }
 
 /* Base resets */
@@ -80,11 +80,11 @@ body {
     padding: 10px;
     padding-top: 8px;
     /* Reduce top padding slightly */
-    background-color: #F5F5F5;
-    color: #616161;
+    background-color: var(--p-silver-100);
+    color: var(--p-silver-700);
     text-align: center;
     line-height: 1.5;
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--p-silver-300);
     font-size: 0.9rem;
     font-family: -apple-system,
     BlinkMacSystemFont,
@@ -124,8 +124,8 @@ body {
 .tooltip .tooltiptext {
     visibility: hidden;
     width: 120px;
-    background-color: #2A2B32;
-    color: #ECECF1;
+    background-color: var(--p-slate-700);
+    color: var(--p-silver-100);
     text-align: left;
     border-radius: 6px;
     padding: 5px;
@@ -227,10 +227,10 @@ h1 {
     font-weight: 500;
     padding: 0 10px;
     min-width: 34px;
-    border: 1.2px solid #e4e6ee;
+    border: 1.2px solid var(--border-light);
     border-radius: 7px;
     text-align: center;
-    background: #f4f4f8;
+    background: var(--bg-secondary);
     color: var(--text-primary);
     margin-left: 2px;
     vertical-align: middle;
@@ -238,7 +238,7 @@ h1 {
 }
 
 .key-input:focus {
-    border-color: #007aff;
+    border-color: var(--highlight-color);
     outline: none;
 }
 
@@ -257,74 +257,17 @@ h1 {
     font-size: 0.93em;
     border-radius: 7px;
     border: 1px solid var(--border-light);
-    background: #f7f8fa;
+    background: var(--bg-secondary);
     padding: 0 6px;
     margin-left: 2px;
 }
 
-/* Smaller switches, always vertically centered */
 .p-form-switch {
     --width: 44px;
-    /* macOS/iOS native: 44 or 51px; 44 is HIG macOS */
-    --height: 28px;
-    /* macOS: 28px; iOS: 31px */
-    width: var(--width) !important;
-    height: var(--height) !important;
-    min-width: var(--width) !important;
-    min-height: var(--height) !important;
-    display: inline-flex;
-    align-items: center;
-    vertical-align: middle;
     margin-left: 0.3em;
     margin-right: 0.2em;
-    position: relative;
 }
 
-.p-form-switch input[type="checkbox"] {
-    opacity: 0;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    left: 0;
-    top: 0;
-    margin: 0;
-    cursor: pointer;
-    z-index: 2;
-}
-
-.p-form-switch span {
-    display: block;
-    width: 100%;
-    height: 100%;
-    border-radius: 999px;
-    background: #e0e0e0;
-    position: relative;
-    transition: background 0.17s;
-    box-shadow: 0 1.5px 5px rgba(120, 150, 255, 0.09);
-}
-
-.p-form-switch input[type="checkbox"]:checked+span {
-    background: #34c759;
-}
-
-.p-form-switch span::after {
-    content: '';
-    position: absolute;
-    left: 3px;
-    top: 3px;
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    background: #fff;
-    box-shadow: 0 2px 6px rgba(100, 140, 220, 0.11);
-    transition: left 0.17s cubic-bezier(.6, .2, .3, 1), background 0.13s;
-}
-
-.p-form-switch input[type="checkbox"]:checked+span::after {
-    left: 19px;
-    /* 44-22-3 = 19 */
-    background: #fff;
-}
 
 
 .shortcut-card {
@@ -335,7 +278,7 @@ h1 {
     margin-bottom: 1rem;
     padding: 1.1rem 1.2rem 1rem 1.2rem;
     border-radius: 13px;
-    border: 1.5px solid #e3e7ee;
+    border: 1.5px solid var(--border-light);
     /* was #eceefd, now slightly darker */
     box-shadow: 0 4px 24px 0 rgba(60, 100, 220, 0.10);
     /* stronger */
@@ -345,7 +288,7 @@ h1 {
 
 .shortcut-card:hover {
     box-shadow: 0 7px 18px 0 rgba(60, 100, 220, 0.10);
-    border-color: #b7d5ff;
+    border-color: var(--p-blueberry-300);
 }
 
 
@@ -384,7 +327,7 @@ h1 {
     font-size: 0.65rem;
     font-weight: 600;
     color: white;
-    background-color: #2196f3;
+    background-color: var(--highlight-color);
     /* Material blue */
     padding: 2px 6px;
     border-radius: 4px;
@@ -409,7 +352,7 @@ h1 {
     width: 100%;
     height: 4px;
     appearance: none;
-    background: #ccc;
+    background: var(--p-silver-300);
     border-radius: 4px;
     outline: none;
 }
@@ -418,7 +361,7 @@ h1 {
     appearance: none;
     width: 12px;
     height: 12px;
-    background: #2196f3;
+    background: var(--highlight-color);
     border-radius: 50%;
     cursor: pointer;
     margin-top: -4px;
@@ -571,52 +514,6 @@ h1 {
     display: none
 }
 
-/* base segment (label acts as button) */
-.message-selection-group label.p-segment {
-    flex: 1 1 0%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 3px;
-    padding: .45em 1.1em;
-    /* ≈ 7 px × 18 px */
-    font-size: 1.06rem;
-    /* 17 px */
-    font-weight: 500;
-    color: var(--segment-text);
-    background: none;
-    cursor: pointer;
-    border: none;
-    border-right: 1px solid var(--segment-border);
-    transition: background .14s, color .14s;
-}
-
-.message-selection-group label.p-segment:last-of-type {
-    border-right: none;
-    /* no divider on far right */
-}
-
-/* active state driven purely by :checked */
-.message-selection-group input[type="radio"]:checked+label.p-segment {
-    background: var(--segment-active-bg);
-    color: var(--segment-active-text);
-    font-weight: 600;
-    box-shadow: 0 2.5px 10px rgba(0, 122, 255, .07);
-}
-
-/* icon + caption inside segment */
-.message-selection-group .material-symbols-outlined {
-    font-size: 16px;
-    line-height: 1;
-    pointer-events: none;
-}
-
-.message-selection-group .segment-text {
-    font-size: .74rem;
-    line-height: 1.15;
-    text-wrap: balance;
-}
 
 /*────────  Disable‑Auto‑Copy toggle row  ────────*/
 .auto-copy-toggle.shortcut-item {
@@ -643,9 +540,9 @@ h1 {
 }
 
 .disabled-section .key-input {
-    background-color: #eee;
-    color: #aaa;
-    border-color: #ccc;
+    background-color: var(--p-silver-100);
+    color: var(--p-silver-500);
+    border-color: var(--p-silver-300);
     cursor: not-allowed;
 }
 
@@ -659,64 +556,12 @@ body {
 }
 
 .shortcut-container,
-.p-tabs-container,
-.p-panel,
 .shortcut-grid {
     overflow-x: hidden;
 }
 
 
 
-/* PRIMARY TABS */
-.p-tabs-container {
-    width: 450px;
-    /* Match your .shortcut-card width! */
-    max-width: 100vw;
-    margin: 0 auto 1.3rem auto;
-    /* Centered and spaced from cards below */
-    background: none;
-    border: none;
-    box-shadow: none;
-    padding: 0;
-}
-
-.p-tabs {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    /* Stretch inside .p-tabs-container, NOT page */
-    gap: 0;
-    background: none;
-    border: none;
-    margin-bottom: 0;
-}
-
-.p-tab {
-    border-radius: 10px;
-    /* Remove/minimize borders for a modern look */
-    border: none;
-    margin: 0 1.5px;
-    padding: 0.5em 1.8em;
-    /* Soft capsule, not huge */
-    min-width: 0;
-    font-size: 1.01rem;
-}
-
-.p-tabs> :first-child {
-    border-radius: 12px 0 0 12px;
-}
-
-.p-tabs> :last-child {
-    border-radius: 0 12px 12px 0;
-}
-
-
-.p-tab.p-is-active {
-    color: #1e1e1e;
-    border-bottom: 2.5px solid #007aff;
-    background: #f8f7f5;
-}
 
 
 
@@ -735,7 +580,7 @@ body {
 .p-card-header {
     font-size: 1.01rem;
     font-weight: 600;
-    color: #444;
+    color: var(--text-primary);
     margin-bottom: 0.7rem;
 }
 
@@ -744,7 +589,7 @@ body {
     justify-content: space-between;
     align-items: center;
     padding: 0.45em 0;
-    border-bottom: 1px solid #f2f2f5;
+    border-bottom: 1px solid var(--p-silver-100);
 }
 
 .shortcut-row:last-child {
@@ -760,16 +605,16 @@ body {
 .shortcut-keys input[type="text"] {
     width: 40px;
     border-radius: 6px;
-    border: 1px solid #e2e2e6;
-    background: #f8f8fb;
+    border: 1px solid var(--border-light);
+    background: var(--bg-secondary);
     text-align: center;
     font-weight: 500;
-    color: #444;
+    color: var(--text-primary);
     transition: border-color .13s;
 }
 
 .shortcut-keys input[type="text"]:focus {
-    border-color: #007aff;
+    border-color: var(--highlight-color);
     outline: none;
 }
 
@@ -800,91 +645,13 @@ body {
 }
 
 .shortcut-card .shortcut-item:not(:last-child) {
-    border-bottom: 1px solid #f5f5f7;
+    border-bottom: 1px solid var(--p-silver-100);
 }
 
 .shortcut-card .shortcut-item:last-child {
     margin-bottom: 0;
 }
 /*────────  Cupertino‑style segmented control  ────────*/
-.p-segmented-controls {
-    display: flex;
-    border: 1.5px solid var(--segment-border);
-    border-radius: 13px;
-    background: var(--segment-bg);
-    /* light grey panel */
-    max-width: 420px;
-    width: 100%;
-    margin: 0 auto 1.2rem auto;
-    overflow: hidden;
-    box-shadow: 0 2px 6px rgba(90, 130, 220, .08);
-}
-
-/* base segment */
-.p-segment {
-    flex: 1 1 0%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 3px;
-    padding: .42em 1.1em;
-    /* ≈ 7 × 18 px */
-    min-height: 32px;
-    font-size: 1.06rem;
-    /* 17 px */
-    font-weight: 500;
-    color: var(--segment-text);
-    background: none;
-    border: none;
-    cursor: pointer;
-    transition: background .14s, color .14s, box-shadow .14s;
-    position: relative;
-}
-
-/* vertical divider between *inactive* segments only  */
-.p-segment+.p-segment {
-    box-shadow: -1px 0 0 0 var(--segment-border) inset;
-}
-
-/* active look — solid accent tint, white text */
-.p-segment.p-is-active {
-    background: #007aff;
-    /* native accent blue */
-    color: #fff;
-    font-weight: 600;
-    box-shadow: none;
-    /* remove outer shadow */
-}
-
-/* hide divider on the active segment and its right neighbour */
-.p-segment.p-is-active {
-    box-shadow: none;
-}
-
-.p-segment.p-is-active+.p-segment {
-    box-shadow: none;
-}
-
-/* keyboard focus ring */
-.p-segment:focus-visible {
-    outline: 2px solid #aad1ff;
-    outline-offset: -3px;
-}
-
-@media (max-width:600px) {
-    .p-segmented-controls {
-        border-radius: 9px;
-        font-size: .97rem;
-    }
-
-    .p-segment {
-        font-size: 1rem;
-        padding: .34em .9em;
-        min-height: 30px;
-    }
-}
-
 
 .shortcut-toggle-row {
     display: flex;
@@ -913,33 +680,6 @@ body {
 }
   
 
-/*──────── FINAL message‑selection overrides ────────*/
-.message-selection-group .p-segment {
-    border: none;
-    /* kill grey ring */
-    background: none;
-    color: var(--segment-text);
-    box-shadow:none !important;
-}
-
-/* thin divider only on inactive neighbours */
-.message-selection-group .p-segment+.p-segment {
-    border-left:1px solid var(--segment-border);
-}
-
-/* active pill */
-.message-selection-group .p-segment.p-is-active {
-    background: #007aff !important;
-    /* full blue fill */
-    color: #fff !important;
-    /* white icon/text */
-    font-weight: 600;
-}
-
-/* remove divider to the right of the active pill */
-.message-selection-group .p-segment.p-is-active+.p-segment {
-    border-left: none;
-}
 
 
 
@@ -977,44 +717,3 @@ body {
     flex: 1 0 0;
 }
 
-/* kill any inset box‑shadow Puppertino adds */
-.message-selection-group .p-segment {
-    box-shadow: none !important
-}
-
-/* divider only between inactive neighbours */
-.message-selection-group .p-segment+.p-segment {
-    border-left: 1px solid var(--segment-border);
-}
-
-/* ACTIVE pill – solid blue fill, white icon/text */
-.message-selection-group .p-segment.p-is-active {
-    background: #007aff !important;
-    color: #fff !important;
-    font-weight: 600;
-    border-left: none;
-    /* erase divider over blue */
-}
-
-.message-selection-group .p-segment.p-is-active+.p-segment {
-    border-left: none;
-    /* no divider on its right edge either */
-}
-
-
-.p-layout,
-.p-large-title,
-.p-headline,
-.p-callout,
-.p-subhead,
-.p-footnote,
-.p-caption {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif !important;
-}
-
-/* tiny type shrink for narrow screens */
-@media(max-width:520px) {
-    .message-selection-group .segment-text {
-        font-size: .70rem
-    }
-}


### PR DESCRIPTION
## Summary
- trim overrides in `popup.css` so Puppertino defaults take effect
- use Puppertino color tokens via CSS variables

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d31fd4fc833096ba953a9c83a5f0