### PR TITLE
Update popup to Puppertino cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The full changelog and feature history is maintained here.
 
+#### [6.6.2025]
+- Switched settings cards to Puppertino `.p-card` markup and styling.
+- Adopted Puppertino form classes for switches and segmented controls.
+- Simplified popup CSS to use built-in Puppertino fonts and spacing.
+
 #### [6.5.2025]
 - Permanently removed "Copy All" buttons; features remain accessible via keyboard shortcuts.
 - Automatically disable TopBarToBottom on Codex pages.

--- a/popup.css
+++ b/popup.css
@@ -37,12 +37,6 @@ body {
     justify-content: center;
     align-items: flex-start;
     background: var(--bg-primary);
-    font-family: -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    "Helvetica Neue",
-    Arial,
-    sans-serif;
     font-size: 14px;
 }
 
@@ -86,13 +80,6 @@ body {
     line-height: 1.5;
     border-top: 1px solid #ccc;
     font-size: 0.9rem;
-    font-family: -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    "Helvetica Neue",
-    Arial,
-    sans-serif;
-
     font-weight: 400;
     z-index: 100;
     box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.2);
@@ -244,14 +231,14 @@ h1 {
 
 
 /* Button/toggle vertical centering in row */
-.shortcut-card .shortcut-item>*:last-child {
+.p-card .shortcut-item>*:last-child {
     display: flex;
     align-items: center;
     height: 100%;
 }
 
 /* For the input[type="text"] used in Join & Copy Separator, etc */
-.shortcut-card input[type="text"].material-input {
+.p-card input[type="text"].material-input {
     width: 190px;
     height: 1.8rem;
     font-size: 0.93em;
@@ -327,26 +314,7 @@ h1 {
 }
 
 
-.shortcut-card {
-    max-width: 420px;
-    width: 420px;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 1rem;
-    padding: 1.1rem 1.2rem 1rem 1.2rem;
-    border-radius: 13px;
-    border: 1.5px solid #e3e7ee;
-    /* was #eceefd, now slightly darker */
-    box-shadow: 0 4px 24px 0 rgba(60, 100, 220, 0.10);
-    /* stronger */
-    background: #fff;
-    transition: box-shadow .13s, border-color .13s;
-}
 
-.shortcut-card:hover {
-    box-shadow: 0 7px 18px 0 rgba(60, 100, 220, 0.10);
-    border-color: #b7d5ff;
-}
 
 
 
@@ -670,7 +638,7 @@ body {
 /* PRIMARY TABS */
 .p-tabs-container {
     width: 450px;
-    /* Match your .shortcut-card width! */
+    /* Match p-card width */
     max-width: 100vw;
     margin: 0 auto 1.3rem auto;
     /* Centered and spaced from cards below */
@@ -724,13 +692,6 @@ body {
     margin-bottom: 2rem;
 }
 
-.p-card {
-    background: #fff;
-    border-radius: 13px;
-    box-shadow: 0 2.5px 13px rgba(0, 0, 0, 0.09);
-    padding: 1.1rem 1.3rem;
-    margin-bottom: 0.4rem;
-}
 
 .p-card-header {
     font-size: 1.01rem;
@@ -779,13 +740,13 @@ body {
 
 
 
-.shortcut-card-header {
+.p-card-header {
     font-size: 1.09rem;
     font-weight: 700;
     margin-bottom: 0.85rem;
 }
 
-.shortcut-card .shortcut-item {
+.p-card .shortcut-item {
     border: none;
     border-radius: 0;
     background: transparent;
@@ -799,11 +760,11 @@ body {
     gap: 1rem;
 }
 
-.shortcut-card .shortcut-item:not(:last-child) {
+.p-card .shortcut-item:not(:last-child) {
     border-bottom: 1px solid #f5f5f7;
 }
 
-.shortcut-card .shortcut-item:last-child {
+.p-card .shortcut-item:last-child {
     margin-bottom: 0;
 }
 /*────────  Cupertino‑style segmented control  ────────*/
@@ -1002,15 +963,6 @@ body {
 }
 
 
-.p-layout,
-.p-large-title,
-.p-headline,
-.p-callout,
-.p-subhead,
-.p-footnote,
-.p-caption {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif !important;
-}
 
 /* tiny type shrink for narrow screens */
 @media(max-width:520px) {

--- a/popup.html
+++ b/popup.html
@@ -48,8 +48,8 @@
                         <!-- SHORTCUT GRID (grouped by category for filter logic) -->
                         <div class="shortcut-grid">
                             <!-- Row 1 -->
-                            <div class="shortcut-card" data-cat="scroll">
-                                <div class="shortcut-card-header i18n" data-i18n="card_header_scrolling">
+                            <div class="p-card" data-cat="scroll">
+                                <div class="p-card-header i18n" data-i18n="card_header_scrolling">
                                     Scroll
                                 </div>
 
@@ -116,8 +116,8 @@
                             </div>
 
 
-                            <div class="shortcut-card" data-cat="agent">
-                                <div class="shortcut-card-header" data-i18n="label_model_tools">
+                            <div class="p-card" data-cat="agent">
+                                <div class="p-card-header" data-i18n="label_model_tools">
                                     Model + Tools
                                 </div>
 
@@ -132,16 +132,14 @@
                                             <span class="mp-option-text i18n" data-i18n="label_use_alt">Alt +
                                                 1,2,3,4,5</span>
                                             <input checked id="useAltForModelSwitcherRadio"
-                                                name="useAltOrControlForModelSelection" type="radio"
-                                                class="material-radio" />
+                                                name="useAltOrControlForModelSelection" type="radio" />
                                         </label>
                                         <label class="mp-option tooltip"
                                             data-tooltip="__MSG_tt_use_control_for_picker__" style="gap:2px;">
                                             <span class="mp-option-text i18n" data-i18n="label_use_control">Control +
                                                 1,2,3,4,5</span>
                                             <input id="useControlForModelSwitcherRadio"
-                                                name="useAltOrControlForModelSelection" type="radio"
-                                                class="material-radio" />
+                                                name="useAltOrControlForModelSelection" type="radio" />
                                         </label>
                                     </div>
                                 </div>
@@ -171,8 +169,8 @@
                                 </div>
                             </div>
 
-                            <div class="shortcut-card" data-cat="copy">
-                                <div class="shortcut-card-header i18n" data-i18n="label_copy">
+                            <div class="p-card" data-cat="copy">
+                                <div class="p-card-header i18n" data-i18n="label_copy">
                                     Copy
                                 </div>
                             
@@ -203,7 +201,7 @@
                                     </div>
                                     <label class="p-form-switch">
                                         <input type="checkbox" id="removeMarkdownOnCopyCheckbox"
-                                            name="removeMarkdownOnCopyCheckbox" class="material-checkbox" />
+                                            name="removeMarkdownOnCopyCheckbox" />
                                         <span></span>
                                     </label>
                                 </div>
@@ -241,8 +239,7 @@
                                         <span class="i18n" data-i18n="label_disable_autocopy">Disable Auto‑Copy</span>
                                     </div>
                                     <label class="p-form-switch">
-                                        <input type="checkbox" id="disableCopyAfterSelectCheckbox" name="disableCopyAfterSelectCheckbox"
-                                            class="material-checkbox" />
+                                        <input type="checkbox" id="disableCopyAfterSelectCheckbox" name="disableCopyAfterSelectCheckbox" />
                                         <span></span>
                                     </label>
                                 </div>
@@ -251,8 +248,8 @@
 
 
 
-                            <div class="shortcut-card" data-cat="navigation">
-                                <div class="shortcut-card-header" data-i18n="label_chat_navigation">
+                            <div class="p-card" data-cat="navigation">
+                                <div class="p-card-header" data-i18n="label_chat_navigation">
                                     Chat Navigation
                                 </div>
 
@@ -347,8 +344,8 @@
                                 </div>
                             </div>
 
-                            <div class="shortcut-card" data-cat="message">
-                                <div class="shortcut-card-header" data-i18n="label_message_actions">
+                            <div class="p-card" data-cat="message">
+                                <div class="p-card-header" data-i18n="label_message_actions">
                                     Message Actions
                                 </div>
 
@@ -420,8 +417,8 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="shortcut-card" data-cat="joinAndCopy">
-                                <div class="shortcut-card-header" data-i18n="label_join_all">
+                            <div class="p-card" data-cat="joinAndCopy">
+                                <div class="p-card-header" data-i18n="label_join_all">
                                     Join &amp; Copy
                                 </div>
 
@@ -480,8 +477,8 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="shortcut-card" data-cat="interface">
-                                <div class="shortcut-card-header" data-i18n="label_interface_options">
+                            <div class="p-card" data-cat="interface">
+                                <div class="p-card-header" data-i18n="label_interface_options">
                                     Interface Options
                                 </div>
 
@@ -550,8 +547,11 @@
                                 </div>
                                 <!-- Section Right: Checkbox -->
                                 <div class="icon-input-container" style="flex-shrink: 0;">
-                                    <input checked class="material-checkbox" id="moveTopBarToBottomCheckbox"
-                                        name="moveTopBarToBottomCheckbox" type="checkbox" />
+                                    <label class="p-form-switch">
+                                        <input checked id="moveTopBarToBottomCheckbox"
+                                            name="moveTopBarToBottomCheckbox" type="checkbox" />
+                                        <span></span>
+                                    </label>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- switch shortcut groups to use `p-card` components
- apply Puppertino form styles
- simplify fonts and remove custom card CSS

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849d32e0e7c83309ed3ff9267da55dd