### PR TITLE
Add pageUpDownTakeover visibility

### DIFF
--- a/content.js
+++ b/content.js
@@ -94,6 +94,7 @@ function applyVisibilitySettings(data) {
     // Value: [defaultIfUndefined, defaultIfMissing]
     const settingsMap = {
         moveTopBarToBottomCheckbox: false,
+        pageUpDownTakeover: true,
         hideArrowButtonsCheckbox: false,
         removeMarkdownOnCopyCheckbox: true,
         selectMessagesSentByUserOrChatGptCheckbox: true,
@@ -130,6 +131,7 @@ window.applyVisibilitySettings = applyVisibilitySettings;
     chrome.storage.sync.get([
         'hideArrowButtonsCheckbox',
         'moveTopBarToBottomCheckbox',
+        'pageUpDownTakeover',
         'removeMarkdownOnCopyCheckbox',
         'selectMessagesSentByUserOrChatGptCheckbox',
         'onlySelectUserCheckbox',


### PR DESCRIPTION
## Summary
- include `pageUpDownTakeover` in content script defaults
- load `pageUpDownTakeover` from storage

## Testing
- `npm ci && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d3c2bb708330983ee974c4a1881c