### PR TITLE
Fix Puppertino overrides

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -530,10 +530,6 @@ body {
     max-width: 100vw;
     margin: 0 auto 1.3rem auto;
     /* Centered and spaced from cards below */
-    background: none;
-    border: none;
-    box-shadow: none;
-    padding: 0;
 }
 
 .p-tabs {
@@ -543,36 +539,15 @@ body {
     width: 100%;
     /* Stretch inside .p-tabs-container, NOT page */
     gap: 0;
-    background: none;
-    border: none;
-    margin-bottom: 0;
 }
 
 .p-tab {
-    border-radius: 10px;
-    /* Remove/minimize borders for a modern look */
-    border: none;
     margin: 0 1.5px;
-    padding: 0.5em 1.8em;
-    /* Soft capsule, not huge */
-    min-width: 0;
     font-size: 1.01rem;
 }
 
-.p-tabs> :first-child {
-    border-radius: 12px 0 0 12px;
-}
-
-.p-tabs> :last-child {
-    border-radius: 0 12px 12px 0;
-}
 
 
-.p-tab.p-is-active {
-    color: #1e1e1e;
-    border-bottom: 2.5px solid #007aff;
-    background: #f8f7f5;
-}
 
 
 


### PR DESCRIPTION
## Summary
- use Puppertino default styling for tab container and tabs

## Testing
- `npm ci && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849dbb0be648330bfdebc49416fdd1c