### PR TITLE
Fix popup font sizes and card spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The full changelog and feature history is maintained here.
 
+#### [6.12.2025]
+- Align popup font sizes with Puppertino layout tokens.
+- Restore default card spacing.
+
 #### [6.11.2025]
 - Adjusted shortcut card margins for improved spacing.
 - Switched tabs and copy-behavior controls to Puppertino scripts.

--- a/popup.css
+++ b/popup.css
@@ -37,7 +37,7 @@ body {
     justify-content: center;
     align-items: flex-start;
     background: var(--bg-primary);
-    font-size: 14px;
+    font-size: 1.15rem;
 }
 
 
@@ -132,7 +132,7 @@ body {
 
 /* Title */
 h1 {
-    font-size: 1.25rem;
+    font-size: 2.25rem;
     font-weight: 500;
     text-align: center;
     margin-bottom: 1rem;
@@ -583,8 +583,8 @@ body {
 
 
 .p-card-header {
-    font-size: 1.01rem;
-    font-weight: 600;
+    font-size: 1.34rem;
+    font-weight: 700;
     color: var(--text-primary);
     margin-bottom: 0.7rem;
 }
@@ -626,11 +626,17 @@ body {
 
 /* Card spacing & layout */
 
+.p-card {
+    margin-top: 30px;
+    padding: 20px 0;
+    border-radius: 25px;
+}
+
 
 
 
 .p-card-header {
-    font-size: 1.09rem;
+    font-size: 1.34rem;
     font-weight: 700;
     margin-bottom: 0.85rem;
 }


### PR DESCRIPTION
## Summary
- align popup fonts with tokens in Puppertino layout
- restore default Puppertino card spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849dbb77b148330a17207c569090623