### PR TITLE
Fix tab layout styles

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -525,24 +525,14 @@ body {
 
 /* PRIMARY TABS */
 .p-tabs-container {
-    width: 450px;
-    /* Match p-card width */
     max-width: 100vw;
-    margin: 0 auto 1.3rem auto;
-    /* Centered and spaced from cards below */
 }
 
 .p-tabs {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    /* Stretch inside .p-tabs-container, NOT page */
-    gap: 0;
+    overflow-x: hidden;
 }
 
 .p-tab {
-    margin: 0 1.5px;
     font-size: 1.01rem;
 }
 


### PR DESCRIPTION
## Summary
- remove custom width, margin, and gap on `.p-tabs-container` and `.p-tabs`
- hide horizontal overflow for tabs

## Testing
- `npm ci`
- `npm test` *(fails: SyntaxError in popupCheckbox.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6849e37ec10c83309b1d4e55fd6f58d9