### PR TITLE
Simplify popup card styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### [6.14.2025]
+- Simplified card CSS to inherit Puppertino defaults.
+
+
 The full changelog and feature history is maintained here.
 
 #### [6.13.2025]

--- a/popup.css
+++ b/popup.css
@@ -591,18 +591,15 @@ body {
 
 /* Card spacing & layout */
 
+
 .p-card {
-    margin-top: 30px;
-    padding: 20px 0;
-    border-radius: 25px;
+    margin-bottom: 2rem;
 }
 
 
 
 
 .p-card-header {
-    font-size: 1.34rem;
-    font-weight: 700;
     margin-bottom: 0.85rem;
 }
 
@@ -611,13 +608,7 @@ body {
     border-radius: 0;
     background: transparent;
     box-shadow: none;
-    padding: 0.19rem 0 0.16rem 0;
     margin-bottom: 1px;
-    min-height: 36px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
 }
 
 


### PR DESCRIPTION
## Summary
- allow Puppertino defaults for card spacing and fonts
- keep minimal overrides for shortcut rows

## Testing
- `npm ci`
- `npm test` *(fails: SyntaxError during tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849e4b9a8e08330bd61ef0b8496f779