### PR TITLE
Fix switch width override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### [6.15.2025]
+- Removed custom switch width to restore Puppertino default size.
+
 #### [6.14.2025]
 - Simplified card CSS to inherit Puppertino defaults.
 

--- a/popup.css
+++ b/popup.css
@@ -250,7 +250,6 @@ h1 {
 }
 
 .p-form-switch {
-    --width: 44px;
     margin-left: 0.3em;
     margin-right: 0.2em;
 }


### PR DESCRIPTION
## Summary
- restore Puppertino default `.p-form-switch` width
- document switch size fix in changelog

## Testing
- `npm test` *(fails: SyntaxError in `popupCheckbox.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5de6e5c83309b2df24e10941e22