### PR TITLE
Adopt Puppertino form markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### [6.16.2025]
+- Converted shortcut rows to Puppertino form markup.
+- Removed custom gap spacing to use default layout.
+
 #### [6.15.2025]
 - Removed custom switch width to restore Puppertino default size.
 

--- a/popup.css
+++ b/popup.css
@@ -142,7 +142,6 @@ h1 {
 .shortcut-grid {
     display: flex;
     flex-direction: column;
-    gap: 6px;
 }
 
 .full-width,
@@ -156,7 +155,6 @@ h1 {
 .shortcut-column {
     display: flex;
     flex-direction: column;
-    gap: 10px;
 }
 
 /* Shortcut Block */
@@ -185,7 +183,6 @@ h1 {
 /* Key Input */
 .shortcut-keys {
     display: flex;
-    gap: 5px;
     align-items: center;
 }
 
@@ -301,7 +298,6 @@ h1 {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 2px;
 }
 
 
@@ -403,7 +399,6 @@ h1 {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 4px;
 
     /* Scale down entire stack if needed */
     transform: scale(0.85);
@@ -567,7 +562,6 @@ body {
 
 .shortcut-keys {
     display: flex;
-    gap: 6px;
     align-items: center;
 }
 
@@ -659,7 +653,6 @@ body {
 .select-copy-row {
     display: grid;
     grid-template-columns: max-content 1fr;
-    column-gap: 1.4rem;
     align-items: center;
 }
 

--- a/popup.html
+++ b/popup.html
@@ -61,7 +61,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyScrollUpOneMessage" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyScrollUpOneMessage" maxlength="1"
                                             name="shortcutKeyScrollUpOneMessage" type="text" value="a" />
                                     </div>
                                 </div>
@@ -74,7 +74,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyScrollDownOneMessage" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyScrollDownOneMessage" maxlength="1"
                                             name="shortcutKeyScrollDownOneMessage" type="text" value="f" />
                                     </div>
                                 </div>
@@ -86,7 +86,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyScrollToTop" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyScrollToTop" maxlength="1"
                                             name="shortcutKeyScrollToTop" type="text" value="t" />
                                     </div>
                                 </div>
@@ -98,7 +98,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyClickNativeScrollToBottom" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyClickNativeScrollToBottom" maxlength="1"
                                             name="shortcutKeyClickNativeScrollToBottom" type="text" value="z" />
                                     </div>
                                 </div>
@@ -127,16 +127,16 @@
                                     <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_pick_model_plain__">
                                         <span class="i18n" data-i18n="label_pickModel">Pick Model</span>
                                     </div>
-                                    <div class="mp-options" style="gap: 2rem; margin-top: 0;">
+                                    <div class="mp-options" style="margin-top: 0;">
                                         <label class="mp-option tooltip" data-tooltip="__MSG_tt_use_alt_for_picker__"
-                                            style="gap:2px;">
+                                             >
                                             <span class="mp-option-text i18n" data-i18n="label_use_alt">Alt +
                                                 1,2,3,4,5</span>
                                             <input checked id="useAltForModelSwitcherRadio"
                                                 name="useAltOrControlForModelSelection" type="radio" />
                                         </label>
                                         <label class="mp-option tooltip"
-                                            data-tooltip="__MSG_tt_use_control_for_picker__" style="gap:2px;">
+                                            data-tooltip="__MSG_tt_use_control_for_picker__"  >
                                             <span class="mp-option-text i18n" data-i18n="label_use_control">Control +
                                                 1,2,3,4,5</span>
                                             <input id="useControlForModelSwitcherRadio"
@@ -152,7 +152,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyToggleModelSelector" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyToggleModelSelector" maxlength="1"
                                             name="shortcutKeyToggleModelSelector" type="text" value="/" />
                                     </div>
                                 </div>
@@ -164,7 +164,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeySearchWeb" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeySearchWeb" maxlength="1"
                                             name="shortcutKeySearchWeb" type="text" value="q" />
                                     </div>
                                 </div>
@@ -181,7 +181,7 @@
                                         <span class="i18n" data-i18n="label_copy_lowest">Copy</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <input class="key-input" id="shortcutKeyCopyLowest" name="shortcutKeyCopyLowest"  type="text" value="c" />
+                                        <input class="key-input p-form-text" id="shortcutKeyCopyLowest" name="shortcutKeyCopyLowest"  type="text" value="c" />
                                     </div>
                                 </div>
                             
@@ -191,7 +191,7 @@
                                         <span class="i18n" data-i18n="label_select_copy">Select &amp; Copy</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <input class="key-input" id="selectThenCopy" name="selectThenCopy"  type="text" value="x" />
+                                        <input class="key-input p-form-text" id="selectThenCopy" name="selectThenCopy"  type="text" value="x" />
                                     </div>
                                 </div>
                             
@@ -264,7 +264,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyNewConversation" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyNewConversation" maxlength="1"
                                             name="shortcutKeyNewConversation" type="text" value="n" />
                                     </div>
                                 </div>
@@ -276,7 +276,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyToggleSidebar" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyToggleSidebar" maxlength="1"
                                             name="shortcutKeyToggleSidebar" type="text" value="s" />
                                     </div>
                                 </div>
@@ -306,7 +306,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyActivateInput" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyActivateInput" maxlength="1"
                                             name="shortcutKeyActivateInput" type="text" value="w" />
                                     </div>
                                 </div>
@@ -318,7 +318,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeySearchConversationHistory" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeySearchConversationHistory" maxlength="1"
                                             name="shortcutKeySearchConversationHistory" type="text" value="k" />
                                     </div>
                                 </div>
@@ -330,7 +330,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyPreviousThread" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyPreviousThread" maxlength="1"
                                             name="shortcutKeyPreviousThread" type="text" value="j" />
                                     </div>
                                 </div>
@@ -342,7 +342,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyNextThread" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyNextThread" maxlength="1"
                                             name="shortcutKeyNextThread" type="text" value=";" />
                                     </div>
                                 </div>
@@ -392,7 +392,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyRegenerate" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyRegenerate" maxlength="1"
                                             name="shortcutKeyRegenerate" type="text" value="r" />
                                     </div>
                                 </div>
@@ -404,7 +404,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyEdit" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyEdit" maxlength="1"
                                             name="shortcutKeyEdit" type="text" value="e" />
                                     </div>
                                 </div>
@@ -416,7 +416,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeySendEdit" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeySendEdit" maxlength="1"
                                             name="shortcutKeySendEdit" type="text" value="d" />
                                     </div>
                                 </div>
@@ -435,7 +435,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyCopyAllResponses" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyCopyAllResponses" maxlength="1"
                                             name="shortcutKeyCopyAllResponses" type="text" value="[" />
                                     </div>
                                 </div>
@@ -448,7 +448,7 @@
                                         </span>
                                     </div>
                                     <div class="icon-input-container">
-                                        <input class="material-input" id="copyAll-userSeparator"
+                                        <input class="material-input p-form-text" id="copyAll-userSeparator"
                                             name="copyAll-userSeparator" type="text" value="\n  \n --- --- --- \n \n" />
                                     </div>
                                 </div>
@@ -462,7 +462,7 @@
                                     </div>
                                     <div class="shortcut-keys">
                                         <span class="key-text platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyCopyAllCodeBlocks" maxlength="1"
+                                        <input class="key-input p-form-text" id="shortcutKeyCopyAllCodeBlocks" maxlength="1"
                                             name="shortcutKeyCopyAllCodeBlocks" type="text" value="]" />
                                     </div>
                                 </div>
@@ -475,7 +475,7 @@
                                         </span>
                                     </div>
                                     <div class="icon-input-container">
-                                        <input class="material-input" id="copyCode-userSeparator"
+                                        <input class="material-input p-form-text" id="copyCode-userSeparator"
                                             name="copyCode-userSeparator" type="text"
                                             value="\n  \n --- --- --- \n \n" />
                                     </div>
@@ -509,7 +509,7 @@
                         <h1>Experimental Features</h1>
                         <div class="shortcut-item">
                             <div
-                                style="display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%;">
+                                style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
                                 <!-- Left: Label -->
                                 <div style="flex: 0 0 auto;">
                                     <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_send_top_bar__"
@@ -525,7 +525,7 @@
                                     <div class="opacity-slider-clipper"
                                         style="width: 100%; height: auto; overflow: visible; display: flex; align-items: center; justify-content: center;">
                                         <div id="opacity-slider-wrapper"
-                                            style="display: flex; flex-direction: column; align-items: center; gap: 4px; width: 100%; max-width: 300px; transform: scale(1); transform-origin: top center;">
+                                            style="display: flex; flex-direction: column; align-items: center; width: 100%; max-width: 300px; transform: scale(1); transform-origin: top center;">
                                             <div style="width: 100%; display: flex; justify-content: center;">
                                                 <svg id="opacityPreviewIcon" preserveaspectratio="xMidYMid meet"
                                                     style="width: 20px; height: 20px; display: block; opacity: 0.6;"
@@ -538,7 +538,7 @@
                                             </div>
                                             <input id="opacitySlider" max="1" min="0" name="opacitySlider" step="0.02"
                                                 style="width: 70%;" type="range" value="0.6" />
-                                            <div style="display: flex; align-items: center; gap: 4px;">
+                                            <div style="display: flex; align-items: center;">
                                                 <span class="i18n" data-i18n="label_opacity" style="font-size: 14px;">
                                                     Opacity:
                                                 </span>


### PR DESCRIPTION
## Summary
- convert shortcut rows to Puppertino text inputs
- drop gap spacing from HTML and CSS
- use Puppertino spacing defaults
- document changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ecb4e10c8330b81c01582785ff91