### PR TITLE
Refine card styling

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -164,14 +164,8 @@ h1 {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background-color: var(--bg-secondary);
-    padding: 0.75rem;
-    border: 1px solid var(--border-light);
-    border-radius: 6px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    padding: 0.75rem 1rem;
     min-height: 3.5rem;
-    /* Adjust as desired */
-
 }
 
 /* Shortcut Name */
@@ -551,6 +545,7 @@ body {
     font-weight: 700;
     color: var(--text-primary);
     margin-bottom: 0.7rem;
+    padding: 0 1rem;
 }
 
 .shortcut-row {
@@ -598,25 +593,22 @@ body {
 
 
 
-.p-card-header {
-    margin-bottom: 0.85rem;
-}
-
 .p-card .shortcut-item {
-    border: none;
-    border-radius: 0;
-    background: transparent;
-    box-shadow: none;
     margin-bottom: 1px;
 }
 
 
-.p-card .shortcut-item:not(:last-child) {
-    border-bottom: 1px solid #f5f5f7;
 
+.p-card .shortcut-item:not(:last-child) {
+    border-bottom: 1px solid var(--p-bd-card);
+}
+
+.p-card .shortcut-item:first-child {
+    padding-top: 0;
 }
 
 .p-card .shortcut-item:last-child {
+    padding-bottom: 0;
     margin-bottom: 0;
 }
 /*────────  Cupertino‑style segmented control  ────────*/


### PR DESCRIPTION
## Summary
- follow Puppertino defaults for card group items
- clean up card header padding

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ecb863e48330908e37504e2aa10c