### PR TITLE
Improve Puppertino styling

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -42,19 +42,9 @@ body {
 
 
 .shortcut-container {
-    width: 750px;
-    max-width: 100%;
-    margin: 0 auto;
-    padding: 1.2rem 0 2.5rem 0;
-    background: none;
-    /* <--- NO background color */
-    border-radius: 0;
-    /* <--- NO border radius */
-    box-shadow: none;
-    /* <--- NO shadow */
-    border: none;
-    /* <--- NO border */
-    display: block;
+  margin: 0 auto;
+  padding: 1rem;
+  max-width: 100%;
 }
 
 
@@ -132,10 +122,8 @@ body {
 
 /* Title */
 h1 {
-    font-size: 2.25rem;
-    font-weight: 500;
-    text-align: center;
-    margin-bottom: 1rem;
+  text-align: center;
+  margin-bottom: 1rem;
 }
 
 /* Grid Layout */
@@ -161,25 +149,18 @@ h1 {
 
 /* Shortcut Block */
 .shortcut-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background-color: var(--bg-secondary);
-    padding: 0.75rem;
-    border: 1px solid var(--border-light);
-    border-radius: 6px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    min-height: 3.5rem;
-    /* Adjust as desired */
-
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  min-height: 3.5rem;
 }
 
 /* Shortcut Name */
 .shortcut-label {
-    font-size: 0.8rem;
-    color: var(--text-primary);
-    font-weight: 500;
-    text-wrap: balance;
+  color: var(--text-primary);
+  font-weight: 500;
+  text-wrap: balance;
 }
 
 /* Key Input */
@@ -190,8 +171,7 @@ h1 {
 }
 
 .key-text {
-    font-size: 0.8rem;
-    font-weight: bold;
+  font-weight: bold;
 }
 
 
@@ -484,8 +464,7 @@ h1 {
 }
 
 .auto-copy-toggle .toggle-label-col {
-    font-size: .97em;
-    color: var(--text-primary);
+  color: var(--text-primary);
 }
 
 #toast-container .toast {
@@ -535,6 +514,101 @@ body {
     font-size: 1.01rem;
 }
 
+/* Utility classes for popup layout */
+.icon-middle {
+  vertical-align: middle;
+}
+
+.mp-options {
+  display: flex;
+  gap: 2rem;
+  margin-top: 0;
+}
+
+.mp-option {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.relative {
+  position: relative;
+}
+
+.flex-between {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+}
+
+.flex-static {
+  flex: 0 0 auto;
+}
+
+.mb-4px {
+  margin-bottom: 4px;
+}
+
+.flex-1-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.flex-column-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  max-width: 300px;
+  transform: scale(1);
+  transform-origin: top center;
+}
+
+.svg-small {
+  width: 20px;
+  height: 20px;
+  display: block;
+  opacity: 0.6;
+}
+
+.w-70 {
+  width: 70%;
+}
+
+.flex-gap-4 {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.icon-input-container {
+  flex-shrink: 0;
+}
+
+#panel-changelog {
+  padding: 0;
+  height: 400px;
+  overflow: hidden;
+}
+
+#panel-changelog .shortcut-container {
+  height: 100%;
+  padding: 0;
+  background: none;
+  box-shadow: none;
+}
+
+.changelog-frame {
+  border: 0;
+  width: 100%;
+  height: 100%;
+}
+
 
 
 
@@ -547,10 +621,9 @@ body {
 
 
 .p-card-header {
-    font-size: 1.34rem;
-    font-weight: 700;
-    color: var(--text-primary);
-    margin-bottom: 0.7rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.7rem;
 }
 
 .shortcut-row {
@@ -633,8 +706,7 @@ body {
 }
 
 .toggle-label-col {
-    font-size: 0.97em;
-    color: var(--text-primary);
+  color: var(--text-primary);
 }
 
 .toggle-switch-col {

--- a/popup.html
+++ b/popup.html
@@ -16,7 +16,7 @@
 
     <div class="p-layout">
         <div class="shortcut-container">
-        <h1 class="i18n" data-i18n="popup_title">
+        <h1 class="p-large-title i18n" data-i18n="popup_title">
             ChatGPT Custom Shortcuts Pro
         </h1>
         <div class="tooltip-area">
@@ -24,16 +24,16 @@
         <div class="p-tabs-container" id="settings-tabs">
             <div class="p-tabs">
                 <button class="p-tab p-is-active" data-panel="panel-shortcuts">
-                    <span class="material-symbols-outlined" style="vertical-align:middle">keyboard_alt</span>
+                    <span class="material-symbols-outlined icon-middle">keyboard_alt</span>
                     Shortcuts
                 </button>
 
                 <button class="p-tab" data-panel="panel-experimental">
-                    <span class="material-symbols-outlined" style="vertical-align:middle">science</span>
+                    <span class="material-symbols-outlined icon-middle">science</span>
                     Experimental
                 </button>
                 <button class="p-tab" data-panel="panel-changelog">
-                    <span class="material-symbols-outlined" style="vertical-align:middle">article</span>
+                    <span class="material-symbols-outlined icon-middle">article</span>
                     Changelog
                 </button>
             </div>
@@ -50,17 +50,17 @@
                         <div class="shortcut-grid">
                             <!-- Row 1 -->
                             <div class="p-card" data-cat="scroll">
-                                <div class="p-card-header i18n" data-i18n="card_header_scrolling">
+                                <div class="p-card-header p-headline i18n" data-i18n="card_header_scrolling">
                                     Scroll
                                 </div>
 
                                 <!-- Scroll Up One Message -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_scroll_up_one__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_scroll_up_one__">
                                         <span class="i18n" data-i18n="label_scroll_up_one">Scroll Up One Message</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyScrollUpOneMessage" maxlength="1"
                                             name="shortcutKeyScrollUpOneMessage" type="text" value="a" />
                                     </div>
@@ -68,12 +68,12 @@
 
                                 <!-- Scroll Down One Message -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_scroll_down_one__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_scroll_down_one__">
                                         <span class="i18n" data-i18n="label_scroll_down_one">Scroll Down One
                                             Message</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyScrollDownOneMessage" maxlength="1"
                                             name="shortcutKeyScrollDownOneMessage" type="text" value="f" />
                                     </div>
@@ -81,11 +81,11 @@
 
                                 <!-- Scroll to Top -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_scroll_top__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_scroll_top__">
                                         <span class="i18n" data-i18n="label_scroll_top">Scroll to Top</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyScrollToTop" maxlength="1"
                                             name="shortcutKeyScrollToTop" type="text" value="t" />
                                     </div>
@@ -93,11 +93,11 @@
 
                                 <!-- Scroll to Bottom -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_scroll_bottom__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_scroll_bottom__">
                                         <span class="i18n" data-i18n="label_scroll_bottom">Scroll to Bottom</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyClickNativeScrollToBottom" maxlength="1"
                                             name="shortcutKeyClickNativeScrollToBottom" type="text" value="z" />
                                     </div>
@@ -105,7 +105,7 @@
 
                                 <!-- PgUp/PgDown Takeover -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_pgup_pgdown__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_pgup_pgdown__">
                                         <span class="i18n" data-i18n="label_pgup_pgdown">PgUp/PgDown Takeover</span>
                                     </div>
                                     <label class="p-form-switch">
@@ -118,25 +118,24 @@
 
 
                             <div class="p-card" data-cat="agent">
-                                <div class="p-card-header" data-i18n="label_model_tools">
+                                <div class="p-card-header p-headline" data-i18n="label_model_tools">
                                     Model + Tools
                                 </div>
 
                                 <!-- Pick Model -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_pick_model_plain__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_pick_model_plain__">
                                         <span class="i18n" data-i18n="label_pickModel">Pick Model</span>
                                     </div>
-                                    <div class="mp-options" style="gap: 2rem; margin-top: 0;">
-                                        <label class="mp-option tooltip" data-tooltip="__MSG_tt_use_alt_for_picker__"
-                                            style="gap:2px;">
+                                    <div class="mp-options">
+                                        <label class="mp-option tooltip" data-tooltip="__MSG_tt_use_alt_for_picker__">
                                             <span class="mp-option-text i18n" data-i18n="label_use_alt">Alt +
                                                 1,2,3,4,5</span>
                                             <input checked id="useAltForModelSwitcherRadio"
                                                 name="useAltOrControlForModelSelection" type="radio" />
                                         </label>
                                         <label class="mp-option tooltip"
-                                            data-tooltip="__MSG_tt_use_control_for_picker__" style="gap:2px;">
+                                            data-tooltip="__MSG_tt_use_control_for_picker__">
                                             <span class="mp-option-text i18n" data-i18n="label_use_control">Control +
                                                 1,2,3,4,5</span>
                                             <input id="useControlForModelSwitcherRadio"
@@ -147,11 +146,11 @@
 
                                 <!-- Show Model Picker -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_showModelPicker_plain__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_showModelPicker_plain__">
                                         <span class="i18n" data-i18n="label_showModelPicker">Show Model Picker</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyToggleModelSelector" maxlength="1"
                                             name="shortcutKeyToggleModelSelector" type="text" value="/" />
                                     </div>
@@ -159,11 +158,11 @@
 
                                 <!-- Search the Web -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_search_web__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_search_web__">
                                         <span class="i18n" data-i18n="label_search_web">Search the Web</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeySearchWeb" maxlength="1"
                                             name="shortcutKeySearchWeb" type="text" value="q" />
                                     </div>
@@ -171,13 +170,13 @@
                             </div>
 
                             <div class="p-card" data-cat="copy">
-                                <div class="p-card-header i18n" data-i18n="label_copy">
+                                <div class="p-card-header p-headline i18n" data-i18n="label_copy">
                                     Copy
                                 </div>
                             
                                 <!-- Copy Lowest Shortcut -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_copy_lowest__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_copy_lowest__">
                                         <span class="i18n" data-i18n="label_copy_lowest">Copy</span>
                                     </div>
                                     <div class="shortcut-keys">
@@ -187,7 +186,7 @@
                             
                                 <!-- Select Then Copy Shortcut -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_select_copy__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_select_copy__">
                                         <span class="i18n" data-i18n="label_select_copy">Select &amp; Copy</span>
                                     </div>
                                     <div class="shortcut-keys">
@@ -197,7 +196,7 @@
                             
                                 <!-- Remove Markdown on Copy Checkbox -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_strip_md__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_strip_md__">
                                         <span class="i18n" data-i18n="label_strip_md">Remove Markdown on Copy</span>
                                     </div>
                                     <label class="p-form-switch">
@@ -209,7 +208,7 @@
                             
                                 <!-- Select + Copy Behavior -->
                                 <div class="shortcut-item select-copy-row">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_select_copy_behavior__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_select_copy_behavior__">
                                         <span class="i18n" data-i18n="label_select_copy_behavior">Select + Copy Behavior</span>
                                     </div>
                                     <div class="shortcut-keys">
@@ -239,7 +238,7 @@
                             
                                 <!-- Disable Auto‑Copy after Selection -->
                                 <div class="shortcut-item shortcut-toggle-row auto-copy-toggle">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_disable_autocopy__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_disable_autocopy__">
                                         <span class="i18n" data-i18n="label_disable_autocopy">Disable Auto‑Copy</span>
                                     </div>
                                     <label class="p-form-switch">
@@ -253,17 +252,17 @@
 
 
                             <div class="p-card" data-cat="navigation">
-                                <div class="p-card-header" data-i18n="label_chat_navigation">
+                                <div class="p-card-header p-headline" data-i18n="label_chat_navigation">
                                     Chat Navigation
                                 </div>
 
                                 <!-- New Conversation -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_new_chat__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_new_chat__">
                                         <span class="i18n" data-i18n="label_new_chat">New Conversation</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyNewConversation" maxlength="1"
                                             name="shortcutKeyNewConversation" type="text" value="n" />
                                     </div>
@@ -271,11 +270,11 @@
 
                                 <!-- Toggle Sidebar -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_toggle_sidebar__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_toggle_sidebar__">
                                         <span class="i18n" data-i18n="label_toggle_sidebar">Toggle Sidebar</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyToggleSidebar" maxlength="1"
                                             name="shortcutKeyToggleSidebar" type="text" value="s" />
                                     </div>
@@ -283,7 +282,7 @@
 
                                 <!-- Remember Sidebar Scroll Position -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip"
+                                    <div class="shortcut-label p-callout tooltip"
                                         data-tooltip="__MSG_tt_rememberSidebarScrollPositionCheckbox__">
                                         <span class="i18n force-balance-break"
                                             data-i18n="label_rememberSidebarScrollPositionCheckbox">
@@ -301,11 +300,11 @@
 
                                 <!-- Focus Chat Input -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_focus_input__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_focus_input__">
                                         <span class="i18n" data-i18n="label_focus_input">Focus Chat Input</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyActivateInput" maxlength="1"
                                             name="shortcutKeyActivateInput" type="text" value="w" />
                                     </div>
@@ -313,11 +312,11 @@
 
                                 <!-- Search Chats -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_search_chats__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_search_chats__">
                                         <span class="i18n" data-i18n="label_search_chats">Search Chats</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeySearchConversationHistory" maxlength="1"
                                             name="shortcutKeySearchConversationHistory" type="text" value="k" />
                                     </div>
@@ -325,11 +324,11 @@
 
                                 <!-- Previous Thread -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_prev_thread__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_prev_thread__">
                                         <span class="i18n" data-i18n="label_prev_thread">Go to Previous Thread</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyPreviousThread" maxlength="1"
                                             name="shortcutKeyPreviousThread" type="text" value="j" />
                                     </div>
@@ -337,11 +336,11 @@
 
                                 <!-- Next Thread -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_next_thread__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_next_thread__">
                                         <span class="i18n" data-i18n="label_next_thread">Go to Next Thread</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyNextThread" maxlength="1"
                                             name="shortcutKeyNextThread" type="text" value=";" />
                                     </div>
@@ -349,7 +348,7 @@
                             </div>
 
                             <div class="p-card" data-cat="message">
-                                <div class="p-card-header" data-i18n="label_message_actions">
+                                <div class="p-card-header p-headline" data-i18n="label_message_actions">
                                     Message Actions
                                 </div>
 
@@ -386,12 +385,12 @@
 
 
                                 <!-- Regenerate Response -->
-                                <div class="shortcut-item" style="position: relative;">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_regenerate__">
+                                <div class="shortcut-item relative">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_regenerate__">
                                         <span class="i18n" data-i18n="label_regenerate">Regenerate Response</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyRegenerate" maxlength="1"
                                             name="shortcutKeyRegenerate" type="text" value="r" />
                                     </div>
@@ -399,11 +398,11 @@
 
                                 <!-- Edit Message -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_edit_msg__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_edit_msg__">
                                         <span class="i18n" data-i18n="label_edit_msg">Edit Message</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyEdit" maxlength="1"
                                             name="shortcutKeyEdit" type="text" value="e" />
                                     </div>
@@ -411,30 +410,30 @@
 
                                 <!-- Send Edited Message -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_send_edit__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_send_edit__">
                                         <span class="i18n" data-i18n="label_send_edit">Send Edited Message</span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeySendEdit" maxlength="1"
                                             name="shortcutKeySendEdit" type="text" value="d" />
                                     </div>
                                 </div>
                             </div>
                             <div class="p-card" data-cat="joinAndCopy">
-                                <div class="p-card-header" data-i18n="label_join_all">
+                                <div class="p-card-header p-headline" data-i18n="label_join_all">
                                     Join &amp; Copy
                                 </div>
 
                                 <!-- Join & Copy All Responses -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_join_all__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_join_all__">
                                         <span class="i18n" data-i18n="label_join_all">
                                             Join All Responses
                                         </span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyCopyAllResponses" maxlength="1"
                                             name="shortcutKeyCopyAllResponses" type="text" value="[" />
                                     </div>
@@ -442,7 +441,7 @@
 
                                 <!-- Join & Copy Separator -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_join_separator__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_join_separator__">
                                         <span class="i18n" data-i18n="label_join_separator">
                                             Join &amp; Copy Separator
                                         </span>
@@ -455,13 +454,13 @@
 
                                 <!-- Join & Copy All Code Boxes -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_join_code__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_join_code__">
                                         <span class="i18n" data-i18n="label_join_code">
                                             Join &amp; Copy All Code Boxes
                                         </span>
                                     </div>
                                     <div class="shortcut-keys">
-                                        <span class="key-text platform-alt-label">Alt +</span>
+                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
                                         <input class="key-input" id="shortcutKeyCopyAllCodeBlocks" maxlength="1"
                                             name="shortcutKeyCopyAllCodeBlocks" type="text" value="]" />
                                     </div>
@@ -469,7 +468,7 @@
 
                                 <!-- Code Box Separator -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_code_separator__">
+                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_code_separator__">
                                         <span class="i18n" data-i18n="label_code_separator">
                                             Code Box Separator
                                         </span>
@@ -482,13 +481,13 @@
                                 </div>
                             </div>
                             <div class="p-card" data-cat="interface">
-                                <div class="p-card-header" data-i18n="label_interface_options">
+                                <div class="p-card-header p-headline" data-i18n="label_interface_options">
                                     Interface Options
                                 </div>
 
                                 <!-- Hide Arrow Buttons -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label">
+                                    <div class="shortcut-label p-callout">
                                         <span class="i18n" data-i18n="label_hide_arrows">Hide Arrow Buttons</span>
                                     </div>
                                     <label class="p-form-switch tooltip" data-tooltip="__MSG_tt_hide_arrows__">
@@ -506,14 +505,12 @@
                 <!--@note EXPERIMENTAL TAB -->
                 <div class="p-panel" id="panel-experimental">
                     <div class="shortcut-container">
-                        <h1>Experimental Features</h1>
+                        <h1 class="p-headline">Experimental Features</h1>
                         <div class="shortcut-item">
-                            <div
-                                style="display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%;">
+                            <div class="flex-between">
                                 <!-- Left: Label -->
-                                <div style="flex: 0 0 auto;">
-                                    <div class="shortcut-label tooltip" data-tooltip="__MSG_tt_send_top_bar__"
-                                        style="margin-bottom: 4px;">
+                                <div class="flex-static">
+                                    <div class="shortcut-label p-callout tooltip mb-4px" data-tooltip="__MSG_tt_send_top_bar__">
                                         <label for="enableSendFromTopBar" data-i18n="label_send_top_bar">
                                             Send Top Bar To Bottom </label>
                                     </div>
@@ -521,14 +518,12 @@
                                 <!-- Center: Opacity slider block wrapped in tooltip -->
                                 <div class="tooltip opacity-tooltip visible-opacity-slider"
                                     data-tooltip="__MSG_tt_opacity_slider__" id="opacity-tooltip-container"
-                                    style="flex: 1; display: flex; justify-content: center; align-items: center;">
-                                    <div class="opacity-slider-clipper"
-                                        style="width: 100%; height: auto; overflow: visible; display: flex; align-items: center; justify-content: center;">
-                                        <div id="opacity-slider-wrapper"
-                                            style="display: flex; flex-direction: column; align-items: center; gap: 4px; width: 100%; max-width: 300px; transform: scale(1); transform-origin: top center;">
-                                            <div style="width: 100%; display: flex; justify-content: center;">
+                                    class="flex-1-center">
+                                    <div class="opacity-slider-clipper">
+                                        <div id="opacity-slider-wrapper" class="flex-column-center">
+                                            <div class="flex-1-center">
                                                 <svg id="opacityPreviewIcon" preserveaspectratio="xMidYMid meet"
-                                                    style="width: 20px; height: 20px; display: block; opacity: 0.6;"
+                                                    class="svg-small"
                                                     viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                                                     <path
                                                         d="M8.85719 3H15.1428C16.2266 2.99999 17.1007 2.99998 17.8086 3.05782C18.5375 3.11737 19.1777 3.24318 19.77 3.54497C20.7108 4.02433 21.4757 4.78924 21.955 5.73005C22.2568 6.32234 22.3826 6.96253 22.4422 7.69138C22.5 8.39925 22.5 9.27339 22.5 10.3572V13.6428C22.5 14.7266 22.5 15.6008 22.4422 16.3086C22.3826 17.0375 22.2568 17.6777 21.955 18.27C21.4757 19.2108 20.7108 19.9757 19.77 20.455C19.1777 20.7568 18.5375 20.8826 17.8086 20.9422C17.1008 21 16.2266 21 15.1428 21H8.85717C7.77339 21 6.89925 21 6.19138 20.9422C5.46253 20.8826 4.82234 20.7568 4.23005 20.455C3.28924 19.9757 2.52433 19.2108 2.04497 18.27C1.74318 17.6777 1.61737 17.0375 1.55782 16.3086C1.49998 15.6007 1.49999 14.7266 1.5 13.6428V10.3572C1.49999 9.27341 1.49998 8.39926 1.55782 7.69138C1.61737 6.96253 1.74318 6.32234 2.04497 5.73005C2.52433 4.78924 3.28924 4.02433 4.23005 3.54497C4.82234 3.24318 5.46253 3.11737 6.19138 3.05782C6.89926 2.99998 7.77341 2.99999 8.85719 3ZM6.35424 5.05118C5.74907 5.10062 5.40138 5.19279 5.13803 5.32698C4.57354 5.6146 4.1146 6.07354 3.82698 6.63803C3.69279 6.90138 3.60062 7.24907 3.55118 7.85424C3.50078 8.47108 3.5 9.26339 3.5 10.4V13.6C3.5 14.7366 3.50078 15.5289 3.55118 16.1458C3.60062 16.7509 3.69279 17.0986 3.82698 17.362C4.1146 17.9265 4.57354 18.3854 5.13803 18.673C5.40138 18.8072 5.74907 18.8994 6.35424 18.9488C6.97108 18.9992 7.76339 19 8.9 19H9.5V5H8.9C7.76339 5 6.97108 5.00078 6.35424 5.05118ZM11.5 5V19H15.1C16.2366 19 17.0289 18.9992 17.6458 18.9488C18.2509 18.8994 18.5986 18.8072 18.862 18.673C19.4265 18.3854 19.8854 17.9265 20.173 17.362C20.3072 17.0986 20.3994 16.7509 20.4488 16.1458C20.4992 15.5289 20.5 14.7366 20.5 13.6V10.4C20.5 9.26339 20.4992 8.47108 20.4488 7.85424C20.3994 7.24907 20.3072 6.90138 20.173 6.63803C19.8854 6.07354 19.4265 5.6146 18.862 5.32698C18.5986 5.19279 18.2509 5.10062 17.6458 5.05118C17.0289 5.00078 16.2366 5 15.1 5H11.5ZM5 8.5C5 7.94772 5.44772 7.5 6 7.5H7C7.55229 7.5 8 7.94772 8 8.5C8 9.05229 7.55229 9.5 7 9.5H6C5.44772 9.5 5 9.05229 5 8.5ZM5 12C5 11.4477 5.44772 11 6 11H7C7.55229 11 8 11.4477 8 12C8 12.5523 7.55229 13 7 13H6C5.44772 13 5 12.5523 5 12Z"
@@ -537,12 +532,12 @@
                                                 </svg>
                                             </div>
                                             <input id="opacitySlider" max="1" min="0" name="opacitySlider" step="0.02"
-                                                style="width: 70%;" type="range" value="0.6" />
-                                            <div style="display: flex; align-items: center; gap: 4px;">
-                                                <span class="i18n" data-i18n="label_opacity" style="font-size: 14px;">
+                                                class="w-70" type="range" value="0.6" />
+                                            <div class="flex-gap-4">
+                                                <span class="i18n p-caption" data-i18n="label_opacity">
                                                     Opacity:
                                                 </span>
-                                                <span id="opacityValue" style="font-size: 14px;">
+                                                <span id="opacityValue" class="p-caption">
                                                     0.6
                                                 </span>
                                             </div>
@@ -550,7 +545,7 @@
                                     </div>
                                 </div>
                                 <!-- Section Right: Checkbox -->
-                                <div class="icon-input-container" style="flex-shrink: 0;">
+                                <div class="icon-input-container">
                                     <label class="p-form-switch">
                                         <input checked id="moveTopBarToBottomCheckbox"
                                             name="moveTopBarToBottomCheckbox" type="checkbox" />
@@ -563,10 +558,10 @@
                 </div>
 
                 <!-- @note CHANGELOG TAB -->
-                <div class="p-panel" id="panel-changelog" style="padding:0;height:400px;overflow:hidden;">
-                    <div class="shortcut-container" style="height:100%;padding:0;background:none;box-shadow:none;">
+                <div class="p-panel" id="panel-changelog">
+                    <div class="shortcut-container">
                         <iframe src="https://bwhurd.github.io/chatgpt-custom-shortcuts-pro/CHANGELOG.html"
-                            style="border:0;width:100%;height:100%"></iframe>
+                            class="changelog-frame"></iframe>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- streamline popup layout to use Puppertino defaults
- switch headings and labels to Puppertino font classes
- add utility classes to replace inline styles
- clean up experimental slider markup

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ecb016988330b3a2223bc958d3bf