### PR TITLE
Fix popup radio inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+#### [6.17.2025]
+##### Fixed
+- Restore message selection radio inputs.
+- Readd leading space in separator values.
+
+
 #### [6.16.2025]
 - Converted shortcut rows to Puppertino form markup.
 - Removed custom gap spacing to use default layout.

--- a/popup.html
+++ b/popup.html
@@ -227,18 +227,24 @@
                                             <a href="#" class="p-segment active tooltip"
                                                 data-setting="selectMessagesSentByUserOrChatGptCheckbox"
                                                 data-tooltip="__MSG_tt_select_all__">
+                                                <input type="radio" id="selectMessagesSentByUserOrChatGptCheckbox"
+                                                    name="messageSelection" />
                                                 <span class="material-symbols-outlined">forum</span>
                                                 <span class="segment-text">User&nbsp;&amp;&nbsp;Assistant</span>
                                             </a>
                                             <a href="#" class="p-segment tooltip"
                                                 data-setting="onlySelectAssistantCheckbox"
                                                 data-tooltip="__MSG_tt_select_assistant__">
+                                                <input type="radio" id="onlySelectAssistantCheckbox"
+                                                    name="messageSelection" />
                                                 <span class="material-symbols-outlined">3p</span>
                                                 <span class="segment-text">Assistant</span>
                                             </a>
                                             <a href="#" class="p-segment tooltip"
                                                 data-setting="onlySelectUserCheckbox"
                                                 data-tooltip="__MSG_tt_select_user__">
+                                                <input type="radio" id="onlySelectUserCheckbox"
+                                                    name="messageSelection" />
                                                 <span class="material-symbols-outlined">mode_comment</span>
                                                 <span class="segment-text">User</span>
                                             </a>
@@ -468,7 +474,7 @@
                                     </div>
                                     <div class="icon-input-container">
                                         <input class="material-input p-form-text" id="copyAll-userSeparator"
-                                            name="copyAll-userSeparator" type="text" value="\n  \n --- --- --- \n \n" />
+                                            name="copyAll-userSeparator" type="text" value=" \n  \n --- --- --- \n \n" />
                                     </div>
                                 </div>
 
@@ -497,7 +503,7 @@
                                     <div class="icon-input-container">
                                         <input class="material-input p-form-text" id="copyCode-userSeparator"
                                             name="copyCode-userSeparator" type="text"
-                                            value="\n  \n --- --- --- \n \n" />
+                                            value=" \n  \n --- --- --- \n \n" />
                                     </div>
                                 </div>
                             </div>

--- a/popup.js
+++ b/popup.js
@@ -287,11 +287,15 @@ document.addEventListener('DOMContentLoaded', function () {
             document.getElementById('moveTopBarToBottomCheckbox').checked = defaults.moveTopBarToBottomCheckbox;
             document.getElementById('pageUpDownTakeover').checked = defaults.pageUpDownTakeover;
             const selectionAnchors = document.querySelectorAll('.message-selection-group a');
-            let activeSelection = 'selectMessagesSentByUserOrChatGptCheckbox';
+            let activeSelection = null;
+            if (defaults.selectMessagesSentByUserOrChatGptCheckbox) activeSelection = 'selectMessagesSentByUserOrChatGptCheckbox';
             if (defaults.onlySelectUserCheckbox) activeSelection = 'onlySelectUserCheckbox';
             if (defaults.onlySelectAssistantCheckbox) activeSelection = 'onlySelectAssistantCheckbox';
             selectionAnchors.forEach(a => {
-                a.classList.toggle('active', a.dataset.setting === activeSelection);
+                const isActive = a.dataset.setting === activeSelection;
+                a.classList.toggle('active', isActive);
+                const input = a.querySelector('input[type="radio"]');
+                if (input) input.checked = isActive;
             });
             document.getElementById('disableCopyAfterSelectCheckbox').checked = defaults.disableCopyAfterSelectCheckbox;
             document.getElementById('enableSendWithControlEnterCheckbox').checked = defaults.enableSendWithControlEnterCheckbox;
@@ -367,6 +371,12 @@ document.addEventListener('DOMContentLoaded', function () {
                     onlySelectAssistantCheckbox: false
                 };
                 obj[key] = true;
+                document.querySelectorAll('.message-selection-group a').forEach(a => {
+                    const isActive = a.dataset.setting === key;
+                    a.classList.toggle('active', isActive);
+                    const input = a.querySelector('input[type="radio"]');
+                    if (input) input.checked = isActive;
+                });
                 chrome.storage.sync.set(obj, () => {
                     if (chrome.runtime.lastError) {
                         console.error('Error saving option:', chrome.runtime.lastError);


### PR DESCRIPTION
## Summary
- restore radio inputs for message selection options
- sync segmented control state with radios
- fix default separator values
- update changelog

## Testing
- `npm ci && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849f222a07c8330a54f590e54fb22ee