### PR TITLE
Fix popup layout width and wrapping

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -42,9 +42,9 @@ body {
 
 
 .shortcut-container {
+  max-width: 420px;
   margin: 0 auto;
   padding: 1rem;
-  max-width: 100%;
 }
 
 

--- a/popup.html
+++ b/popup.html
@@ -597,7 +597,7 @@
                 </div>
             </div>
         </div>
-    </div>
+        </div>
     </div>
 
     <!-- SCRIPTS -->
@@ -605,7 +605,9 @@
     <script src="popup.js" defer></script>
     <script src="lib/puppertino/tabs.js"></script>
     <script src="lib/puppertino/segmented_controls.js"></script>
-    
+
+    </div>
+
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- constrain `.shortcut-container` to 420px max width
- move `.p-layout` closing tag so it wraps scripts

## Testing
- `npm ci && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849f43dbacc8330baefc3c0c2750615