### PR TITLE
Align baseline layout for settings rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### [6.18.2025]
+##### Changed
+- Align settings rows using Puppertino baseline layout and spacing tokens.
+
 #### [6.17.2025]
 ##### Fixed
 - Restore message selection radio inputs.

--- a/popup.css
+++ b/popup.css
@@ -227,8 +227,8 @@ h1 {
 }
 
 .p-form-switch {
-    margin-left: 0.3em;
-    margin-right: 0.2em;
+  margin-left: var(--p-h-spacing);
+  margin-right: var(--p-h-spacing);
 }
 
 

--- a/popup.html
+++ b/popup.html
@@ -109,12 +109,11 @@
 
                                 <!-- PgUp/PgDown Takeover -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_pgup_pgdown__">
+                                    <label class="p-form-label p-callout tooltip" for="pageUpDownTakeover" data-tooltip="__MSG_tt_pgup_pgdown__">
                                         <span class="i18n" data-i18n="label_pgup_pgdown">PgUp/PgDown Takeover</span>
-                                    </div>
+                                    </label>
                                     <label class="p-form-switch">
-                                        <input checked id="pageUpDownTakeover" name="pageUpDownTakeover"
-                                            type="checkbox" />
+                                        <input checked id="pageUpDownTakeover" name="pageUpDownTakeover" type="checkbox" />
                                         <span></span>
                                     </label>
                                 </div>
@@ -206,12 +205,11 @@
                             
                                 <!-- Remove Markdown on Copy Checkbox -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_strip_md__">
+                                    <label class="p-form-label p-callout tooltip" for="removeMarkdownOnCopyCheckbox" data-tooltip="__MSG_tt_strip_md__">
                                         <span class="i18n" data-i18n="label_strip_md">Remove Markdown on Copy</span>
-                                    </div>
+                                    </label>
                                     <label class="p-form-switch">
-                                        <input type="checkbox" id="removeMarkdownOnCopyCheckbox"
-                                            name="removeMarkdownOnCopyCheckbox" />
+                                        <input type="checkbox" id="removeMarkdownOnCopyCheckbox" name="removeMarkdownOnCopyCheckbox" />
                                         <span></span>
                                     </label>
                                 </div>
@@ -254,9 +252,9 @@
                             
                                 <!-- Disable Auto‑Copy after Selection -->
                                 <div class="shortcut-item shortcut-toggle-row auto-copy-toggle">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_disable_autocopy__">
+                                    <label class="p-form-label p-callout tooltip" for="disableCopyAfterSelectCheckbox" data-tooltip="__MSG_tt_disable_autocopy__">
                                         <span class="i18n" data-i18n="label_disable_autocopy">Disable Auto‑Copy</span>
-                                    </div>
+                                    </label>
                                     <label class="p-form-switch">
                                         <input type="checkbox" id="disableCopyAfterSelectCheckbox" name="disableCopyAfterSelectCheckbox" />
                                         <span></span>
@@ -300,17 +298,11 @@
 
                                 <!-- Remember Sidebar Scroll Position -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip"
-                                        data-tooltip="__MSG_tt_rememberSidebarScrollPositionCheckbox__">
-                                        <span class="i18n force-balance-break"
-                                            data-i18n="label_rememberSidebarScrollPositionCheckbox">
-                                            Remember Sidebar Scroll Position
-                                        </span>
-                                    </div>
-                                    <label class="p-form-switch tooltip"
-                                        data-tooltip="__MSG_tt_rememberSidebarScrollPositionCheckbox__">
-                                        <input checked id="rememberSidebarScrollPositionCheckbox"
-                                            name="rememberSidebarScrollPositionCheckbox" type="checkbox" />
+                                    <label class="p-form-label p-callout tooltip" for="rememberSidebarScrollPositionCheckbox" data-tooltip="__MSG_tt_rememberSidebarScrollPositionCheckbox__">
+                                        <span class="i18n force-balance-break" data-i18n="label_rememberSidebarScrollPositionCheckbox">Remember Sidebar Scroll Position</span>
+                                    </label>
+                                    <label class="p-form-switch tooltip" data-tooltip="__MSG_tt_rememberSidebarScrollPositionCheckbox__">
+                                        <input checked id="rememberSidebarScrollPositionCheckbox" name="rememberSidebarScrollPositionCheckbox" type="checkbox" />
                                         <span></span>
                                     </label>
                                 </div>
@@ -514,12 +506,11 @@
 
                                 <!-- Hide Arrow Buttons -->
                                 <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout">
+                                    <label class="p-form-label p-callout" for="hideArrowButtonsCheckbox">
                                         <span class="i18n" data-i18n="label_hide_arrows">Hide Arrow Buttons</span>
-                                    </div>
+                                    </label>
                                     <label class="p-form-switch tooltip" data-tooltip="__MSG_tt_hide_arrows__">
-                                        <input id="hideArrowButtonsCheckbox" name="hideArrowButtonsCheckbox"
-                                            type="checkbox" />
+                                        <input id="hideArrowButtonsCheckbox" name="hideArrowButtonsCheckbox" type="checkbox" />
                                         <span></span>
                                     </label>
                                 </div>


### PR DESCRIPTION
## Summary
- switch `.shortcut-item` markup to Puppertino-style baseline layout
- use Puppertino spacing tokens on `.p-form-switch`
- document change in changelog

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849f4381d40833089f9723a5322a03a