### PR TITLE
Adjust shortcut item spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Tweak card spacing for iOS look.
 - Cleaned popup.css rules duplicated from Puppertino defaults.
 - Align settings rows using Puppertino baseline layout and spacing tokens.
+- Reduce shortcut row min-height to 2.75rem.
 
 
 #### [6.5.2025]

--- a/popup.css
+++ b/popup.css
@@ -135,8 +135,8 @@ h1 {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 0;
-  min-height: 3.5rem;
+  padding: 0.5rem 1rem;
+  min-height: 2.75rem;
 }
 
 /* Shortcut Name */


### PR DESCRIPTION
## Summary
- tweak `.shortcut-item` padding and height in `popup.css`
- note spacing change in `CHANGELOG`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ffc7f5948330a2e6d2b073c26776