### PR TITLE
Fix layout wrapper

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -11,10 +11,9 @@
     </title>
 </head>
 
-    <body>
+    <body class="p-layout">
     <!-- Puppertino and icons CSS -->
 
-    <div class="p-layout">
         <div class="shortcut-container">
         <h1 class="p-headline i18n" data-i18n="popup_title">
             ChatGPT Custom Shortcuts Pro
@@ -597,7 +596,6 @@
     <script src="lib/puppertino/tabs.js"></script>
     <script src="lib/puppertino/segmented_controls.js"></script>
 
-    </div>
 
 </body>
 


### PR DESCRIPTION
## Summary
- set the `<body>` to use the `p-layout` class
- drop redundant wrapper div around popup layout

## Testing
- `npm ci && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849ff9cd2b4833088c52b7b370e8464