### PR TITLE
Update popup background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### [6.12.2025]
+- Set popup background to `var(--p-silver-100)` for gray page tone.
+
 #### [6.11.2025]
 - Adjusted shortcut card margins for improved spacing.
 - Switched tabs and copy-behavior controls to Puppertino scripts.

--- a/popup.css
+++ b/popup.css
@@ -20,7 +20,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  background: var(--bg-primary);
+  background: var(--p-silver-100);
   font-size: 1rem;
   font-family: -apple-system, "Inter", sans-serif;
 }


### PR DESCRIPTION
## Summary
- use Puppertino silver gray for popup body
- document color tweak in changelog

## Testing
- `npm ci && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ffd6c0f48330a9dfb62cfa215715