### PR TITLE
Override Puppertino text sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Reduce shortcut row min-height to 2.75rem.
 - Refined settings card headers with Puppertino subhead styling.
 - Set popup background to `var(--p-silver-100)` for gray page tone.
+- Overrode Puppertino text classes with smaller font sizes for iOS.
 
 
 

--- a/popup.css
+++ b/popup.css
@@ -742,3 +742,32 @@ h1 {
         font-size: .70rem
     }
 }
+
+/* Font size overrides */
+body.p-layout {
+  font-size: 14px;
+}
+.p-layout h1 {
+  font-size: 22px;
+}
+.p-layout h2 {
+  font-size: 20px;
+}
+.p-layout h3 {
+  font-size: 18px;
+}
+.p-headline {
+  font-size: 17px;
+}
+.p-subhead {
+  font-size: 15px;
+}
+.p-callout {
+  font-size: 15px;
+}
+.p-footnote {
+  font-size: 13px;
+}
+.p-caption {
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- reduce popup font sizes to better match iOS
- document font-size override in changelog

## Testing
- `npm ci && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a02b72ef08330a70cd83b650cf7f7