### PR TITLE
Refactor popup shortcut rows

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -168,7 +168,7 @@ h1 {
 
 /* Key input (shortcut key) refinement */
 .key-input {
-    width: 38px;
+    width: 2.4em;
     height: 2rem;
     font-size: 1em;
     font-weight: 500;

--- a/popup.html
+++ b/popup.html
@@ -54,57 +54,32 @@
                                 </div>
 
                                 <!-- Scroll Up One Message -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_scroll_up_one__">
-                                        <span class="i18n" data-i18n="label_scroll_up_one">Scroll Up One Message</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyScrollUpOneMessage" maxlength="1"
-                                            name="shortcutKeyScrollUpOneMessage" type="text" value="a" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_scroll_up_one__">
+                                    <span class="i18n" data-i18n="label_scroll_up_one">Scroll Up One Message</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyScrollUpOneMessage" name="shortcutKeyScrollUpOneMessage" type="text" maxlength="1" value="a" />
+                                </label>
 
                                 <!-- Scroll Down One Message -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_scroll_down_one__">
-                                        <span class="i18n" data-i18n="label_scroll_down_one">Scroll Down One
-                                            Message</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyScrollDownOneMessage" maxlength="1"
-                                            name="shortcutKeyScrollDownOneMessage" type="text" value="f" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_scroll_down_one__">
+                                    <span class="i18n" data-i18n="label_scroll_down_one">Scroll Down One Message</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyScrollDownOneMessage" name="shortcutKeyScrollDownOneMessage" type="text" maxlength="1" value="f" />
+                                </label>
 
                                 <!-- Scroll to Top -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_scroll_top__">
-                                        <span class="i18n" data-i18n="label_scroll_top">Scroll to Top</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyScrollToTop" maxlength="1"
-
-                                            name="shortcutKeyScrollToTop" type="text" value="t" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_scroll_top__">
+                                    <span class="i18n" data-i18n="label_scroll_top">Scroll to Top</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyScrollToTop" name="shortcutKeyScrollToTop" type="text" maxlength="1" value="t" />
+                                </label>
 
                                 <!-- Scroll to Bottom -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_scroll_bottom__">
-                                        <span class="i18n" data-i18n="label_scroll_bottom">Scroll to Bottom</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyClickNativeScrollToBottom" maxlength="1"
-
-                                            name="shortcutKeyClickNativeScrollToBottom" type="text" value="z" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_scroll_bottom__">
+                                    <span class="i18n" data-i18n="label_scroll_bottom">Scroll to Bottom</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyClickNativeScrollToBottom" name="shortcutKeyClickNativeScrollToBottom" type="text" maxlength="1" value="z" />
+                                </label>
 
                                 <!-- PgUp/PgDown Takeover -->
                                 <div class="shortcut-item">
@@ -151,30 +126,18 @@
                                 </div>
 
                                 <!-- Show Model Picker -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_showModelPicker_plain__">
-                                        <span class="i18n" data-i18n="label_showModelPicker">Show Model Picker</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyToggleModelSelector" maxlength="1"
-
-                                            name="shortcutKeyToggleModelSelector" type="text" value="/" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_showModelPicker_plain__">
+                                    <span class="i18n" data-i18n="label_showModelPicker">Show Model Picker</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyToggleModelSelector" name="shortcutKeyToggleModelSelector" type="text" maxlength="1" value="/" />
+                                </label>
 
                                 <!-- Search the Web -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_search_web__">
-                                        <span class="i18n" data-i18n="label_search_web">Search the Web</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeySearchWeb" maxlength="1"
-
-                                            name="shortcutKeySearchWeb" type="text" value="q" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_search_web__">
+                                    <span class="i18n" data-i18n="label_search_web">Search the Web</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeySearchWeb" name="shortcutKeySearchWeb" type="text" maxlength="1" value="q" />
+                                </label>
                             </div>
 
                             <div class="p-card" data-cat="copy">
@@ -183,24 +146,16 @@
                                 </div>
                             
                                 <!-- Copy Lowest Shortcut -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_copy_lowest__">
-                                        <span class="i18n" data-i18n="label_copy_lowest">Copy</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <input class="key-input p-form-text" id="shortcutKeyCopyLowest" name="shortcutKeyCopyLowest"  type="text" value="c" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_copy_lowest__">
+                                    <span class="i18n" data-i18n="label_copy_lowest">Copy</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyCopyLowest" name="shortcutKeyCopyLowest" type="text" maxlength="1" value="c" />
+                                </label>
                             
                                 <!-- Select Then Copy Shortcut -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_select_copy__">
-                                        <span class="i18n" data-i18n="label_select_copy">Select &amp; Copy</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <input class="key-input p-form-text" id="selectThenCopy" name="selectThenCopy"  type="text" value="x" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_select_copy__">
+                                    <span class="i18n" data-i18n="label_select_copy">Select &amp; Copy</span>
+                                    <input class="p-form-text key-input" id="selectThenCopy" name="selectThenCopy" type="text" maxlength="1" value="x" />
+                                </label>
                             
                                 <!-- Remove Markdown on Copy Checkbox -->
                                 <div class="shortcut-item">
@@ -270,30 +225,18 @@
                                 </div>
 
                                 <!-- New Conversation -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_new_chat__">
-                                        <span class="i18n" data-i18n="label_new_chat">New Conversation</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyNewConversation" maxlength="1"
-
-                                            name="shortcutKeyNewConversation" type="text" value="n" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_new_chat__">
+                                    <span class="i18n" data-i18n="label_new_chat">New Conversation</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyNewConversation" name="shortcutKeyNewConversation" type="text" maxlength="1" value="n" />
+                                </label>
 
                                 <!-- Toggle Sidebar -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_toggle_sidebar__">
-                                        <span class="i18n" data-i18n="label_toggle_sidebar">Toggle Sidebar</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyToggleSidebar" maxlength="1"
-
-                                            name="shortcutKeyToggleSidebar" type="text" value="s" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_toggle_sidebar__">
+                                    <span class="i18n" data-i18n="label_toggle_sidebar">Toggle Sidebar</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyToggleSidebar" name="shortcutKeyToggleSidebar" type="text" maxlength="1" value="s" />
+                                </label>
 
                                 <!-- Remember Sidebar Scroll Position -->
                                 <div class="shortcut-item">
@@ -308,56 +251,32 @@
 
 
                                 <!-- Focus Chat Input -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_focus_input__">
-                                        <span class="i18n" data-i18n="label_focus_input">Focus Chat Input</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyActivateInput" maxlength="1"
-
-                                            name="shortcutKeyActivateInput" type="text" value="w" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_focus_input__">
+                                    <span class="i18n" data-i18n="label_focus_input">Focus Chat Input</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyActivateInput" name="shortcutKeyActivateInput" type="text" maxlength="1" value="w" />
+                                </label>
 
                                 <!-- Search Chats -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_search_chats__">
-                                        <span class="i18n" data-i18n="label_search_chats">Search Chats</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeySearchConversationHistory" maxlength="1"
-
-                                            name="shortcutKeySearchConversationHistory" type="text" value="k" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_search_chats__">
+                                    <span class="i18n" data-i18n="label_search_chats">Search Chats</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeySearchConversationHistory" name="shortcutKeySearchConversationHistory" type="text" maxlength="1" value="k" />
+                                </label>
 
                                 <!-- Previous Thread -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_prev_thread__">
-                                        <span class="i18n" data-i18n="label_prev_thread">Go to Previous Thread</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyPreviousThread" maxlength="1"
-
-                                            name="shortcutKeyPreviousThread" type="text" value="j" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_prev_thread__">
+                                    <span class="i18n" data-i18n="label_prev_thread">Go to Previous Thread</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyPreviousThread" name="shortcutKeyPreviousThread" type="text" maxlength="1" value="j" />
+                                </label>
 
                                 <!-- Next Thread -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_next_thread__">
-                                        <span class="i18n" data-i18n="label_next_thread">Go to Next Thread</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyNextThread" maxlength="1"
-
-                                            name="shortcutKeyNextThread" type="text" value=";" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_next_thread__">
+                                    <span class="i18n" data-i18n="label_next_thread">Go to Next Thread</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyNextThread" name="shortcutKeyNextThread" type="text" maxlength="1" value=";" />
+                                </label>
                             </div>
 
                             <div class="p-card" data-cat="message">
@@ -398,43 +317,25 @@
 
 
                                 <!-- Regenerate Response -->
-                                <div class="shortcut-item relative">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_regenerate__">
-                                        <span class="i18n" data-i18n="label_regenerate">Regenerate Response</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyRegenerate" maxlength="1"
-
-                                            name="shortcutKeyRegenerate" type="text" value="r" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip relative" data-tooltip="__MSG_tt_regenerate__">
+                                    <span class="i18n" data-i18n="label_regenerate">Regenerate Response</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyRegenerate" name="shortcutKeyRegenerate" type="text" maxlength="1" value="r" />
+                                </label>
 
                                 <!-- Edit Message -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_edit_msg__">
-                                        <span class="i18n" data-i18n="label_edit_msg">Edit Message</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyEdit" maxlength="1"
-
-                                            name="shortcutKeyEdit" type="text" value="e" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_edit_msg__">
+                                    <span class="i18n" data-i18n="label_edit_msg">Edit Message</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyEdit" name="shortcutKeyEdit" type="text" maxlength="1" value="e" />
+                                </label>
 
                                 <!-- Send Edited Message -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_send_edit__">
-                                        <span class="i18n" data-i18n="label_send_edit">Send Edited Message</span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeySendEdit" maxlength="1"
-
-                                            name="shortcutKeySendEdit" type="text" value="d" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_send_edit__">
+                                    <span class="i18n" data-i18n="label_send_edit">Send Edited Message</span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeySendEdit" name="shortcutKeySendEdit" type="text" maxlength="1" value="d" />
+                                </label>
                             </div>
                             <div class="p-card" data-cat="joinAndCopy">
                                 <div class="p-card-header p-subhead" data-i18n="label_join_all">
@@ -442,19 +343,13 @@
                                 </div>
 
                                 <!-- Join & Copy All Responses -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_join_all__">
-                                        <span class="i18n" data-i18n="label_join_all">
-                                            Join All Responses
-                                        </span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyCopyAllResponses" maxlength="1"
-
-                                            name="shortcutKeyCopyAllResponses" type="text" value="[" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_join_all__">
+                                    <span class="i18n" data-i18n="label_join_all">
+                                        Join All Responses
+                                    </span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyCopyAllResponses" name="shortcutKeyCopyAllResponses" type="text" maxlength="1" value="[" />
+                                </label>
 
                                 <!-- Join & Copy Separator -->
                                 <div class="shortcut-item">
@@ -470,19 +365,13 @@
                                 </div>
 
                                 <!-- Join & Copy All Code Boxes -->
-                                <div class="shortcut-item">
-                                    <div class="shortcut-label p-callout tooltip" data-tooltip="__MSG_tt_join_code__">
-                                        <span class="i18n" data-i18n="label_join_code">
-                                            Join &amp; Copy All Code Boxes
-                                        </span>
-                                    </div>
-                                    <div class="shortcut-keys">
-                                        <span class="key-text p-caption platform-alt-label">Alt +</span>
-                                        <input class="key-input" id="shortcutKeyCopyAllCodeBlocks" maxlength="1"
-
-                                            name="shortcutKeyCopyAllCodeBlocks" type="text" value="]" />
-                                    </div>
-                                </div>
+                                <label class="p-form-label-inline p-callout tooltip" data-tooltip="__MSG_tt_join_code__">
+                                    <span class="i18n" data-i18n="label_join_code">
+                                        Join &amp; Copy All Code Boxes
+                                    </span>
+                                    <span class="p-caption platform-alt-label">Alt +</span>
+                                    <input class="p-form-text key-input" id="shortcutKeyCopyAllCodeBlocks" name="shortcutKeyCopyAllCodeBlocks" type="text" maxlength="1" value="]" />
+                                </label>
 
                                 <!-- Code Box Separator -->
                                 <div class="shortcut-item">


### PR DESCRIPTION
## Summary
- simplify shortcut rows to single labels
- adjust input width for key fields

## Testing
- `npm ci && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a03b7ecf48330bae49489ac7edec2